### PR TITLE
fix: resolve page stuck on 'Umi Loading...' issue

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { history, Link } from '@umijs/max';
 import React from 'react';
 import { AvatarDropdown, AvatarName, Footer, SelectLang } from '@/components';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
+import { getToken } from '@/utils/auth';
 import defaultSettings from '../config/defaultSettings';
 import { errorConfig } from './requestErrorConfig';
 import '@ant-design/v5-patch-for-react-19';
@@ -13,20 +14,7 @@ import '@ant-design/v5-patch-for-react-19';
 const isDev = process.env.NODE_ENV === 'development' || process.env.CI;
 const loginPath = '/user/login';
 
-const TOKEN_KEY = 'rustdesk_access_token';
 const THEME_KEY = 'rustdesk_theme_settings';
-
-export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
-}
-
-export function setToken(token: string) {
-  localStorage.setItem(TOKEN_KEY, token);
-}
-
-export function removeToken() {
-  localStorage.removeItem(TOKEN_KEY);
-}
 
 function getStoredThemeSettings(): Partial<LayoutSettings> | undefined {
   try {

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -5,7 +5,7 @@ import { Spin } from 'antd';
 import { createStyles } from 'antd-style';
 import React from 'react';
 import { flushSync } from 'react-dom';
-import { removeToken } from '@/app';
+import { removeToken } from '@/utils/auth';
 import { logout } from '@/services/rustdesk-console/auth';
 import HeaderDropdown from '../HeaderDropdown';
 

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -11,7 +11,7 @@ import { Alert, App } from 'antd';
 import { createStyles } from 'antd-style';
 import React, { useState } from 'react';
 import { flushSync } from 'react-dom';
-import { setToken } from '@/app';
+import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
 import { login } from '@/services/rustdesk-console/auth';
 import Settings from '../../../../config/defaultSettings';

--- a/src/requestErrorConfig.ts
+++ b/src/requestErrorConfig.ts
@@ -1,8 +1,8 @@
-﻿import type { RequestOptions } from '@@/plugin-request/request';
+import type { RequestOptions } from '@@/plugin-request/request';
 import type { RequestConfig } from '@umijs/max';
 import { history } from '@umijs/max';
 import { message, notification } from 'antd';
-import { getToken, removeToken } from './app';
+import { getToken, removeToken } from '@/utils/auth';
 
 const loginPath = '/user/login';
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,13 @@
+const TOKEN_KEY = 'rustdesk_access_token';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function removeToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}


### PR DESCRIPTION
## Summary

Fixed critical bug where the application was stuck on "Umi Loading..." screen.

## Root Cause

`app.tsx` exported unsupported functions (`getToken`, `setToken`, `removeToken`) which caused UmiJS to fail with:
```
register failed, invalid key getToken from plugin app.tsx
```

UmiJS only allows specific convention exports from `app.tsx`:
- `getInitialState`
- `layout`
- `request`
- etc.

## Changes

- **Create `src/utils/auth.ts`** - Move token management functions to dedicated utility file
- **Update `src/app.tsx`** - Remove unsupported exports, import from `@/utils/auth`
- **Update `src/requestErrorConfig.ts`** - Update import path
- **Update `src/components/RightContent/AvatarDropdown.tsx`** - Update import path
- **Update `src/pages/user/login/index.tsx`** - Update import path

## Verification

- ✅ Build passes: `npx max build`
- ✅ Page loads correctly with title "Login - RustDesk Console"
- ✅ No console errors