### PR TITLE
fix: change pagination parameter from 'page' to 'current' for shared address books API

### DIFF
--- a/src/pages/address-book/shared/index.tsx
+++ b/src/pages/address-book/shared/index.tsx
@@ -150,7 +150,7 @@ const SharedAddressBook: React.FC = () => {
         request={async (params) => {
           const result = await getSharedAddressBooks({
             pageSize: params.pageSize || 10,
-            page: params.current || 1,
+            current: params.current || 1,
           });
           return {
             data: result.data || [],

--- a/src/pages/dashboard/workplace/index.tsx
+++ b/src/pages/dashboard/workplace/index.tsx
@@ -35,7 +35,7 @@ const Workplace: React.FC = () => {
   );
 
   const { data: abData, loading: abLoading } = useRequest(
-    () => getSharedAddressBooks({ pageSize: 1, page: 1 }),
+    () => getSharedAddressBooks({ pageSize: 1, current: 1 }),
     { manual: false },
   );
 

--- a/src/services/rustdesk-console/addressBook.ts
+++ b/src/services/rustdesk-console/addressBook.ts
@@ -17,7 +17,7 @@ export async function getPersonalAddressBook() {
 }
 
 export async function getSharedAddressBooks(
-  params?: { pageSize?: number; page?: number },
+  params?: { pageSize?: number; current?: number },
   options?: { [key: string]: any },
 ) {
   return request<API.PaginatedResult<API.SharedAddressBook>>('/api/ab/shared/profiles', {


### PR DESCRIPTION
## Problem
The shared address books API was returning 400 error with message "property page should not exist" because the backend API expects 'current' parameter instead of 'page' for pagination.

## Solution
- Changed the parameter name from 'page' to 'current' in the getSharedAddressBooks function
- Updated all callers to use the correct parameter name

## Files Changed
- src/services/rustdesk-console/addressBook.ts
- src/pages/address-book/shared/index.tsx
- src/pages/dashboard/workplace/index.tsx

## Testing
Verified with Playwright tests that all API requests now return 200 successfully.