### PR TITLE
feat: add additional UI routes and type definitions

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -20,6 +20,12 @@
     ],
   },
   {
+    path: '/welcome',
+    name: 'welcome',
+    icon: 'smile',
+    component: './welcome',
+  },
+  {
     path: '/dashboard',
     name: 'dashboard',
     icon: 'dashboard',
@@ -77,18 +83,25 @@
     ],
   },
   {
-    path: '/device-groups',
-    name: 'deviceGroups',
-    icon: 'group',
+    path: '/groups',
+    name: 'groups',
+    icon: 'team',
+    access: 'canAdmin',
     routes: [
       {
-        path: '/device-groups',
-        redirect: '/device-groups/list',
+        path: '/groups',
+        redirect: '/groups/user',
       },
       {
-        name: 'list',
-        icon: 'appstore',
-        path: '/device-groups/list',
+        name: 'user',
+        icon: 'user',
+        path: '/groups/user',
+        component: './groups/user',
+      },
+      {
+        name: 'device',
+        icon: 'device',
+        path: '/groups/device',
         component: './device-groups/list',
       },
     ],
@@ -110,6 +123,13 @@
         component: './users/list',
       },
     ],
+  },
+  {
+    path: '/roles',
+    name: 'roles',
+    icon: 'audit',
+    access: 'canAdmin',
+    component: './roles',
   },
   {
     path: '/audits',
@@ -148,8 +168,35 @@
     ],
   },
   {
+    path: '/ab',
+    name: 'addressBooks',
+    icon: 'contacts',
+    component: './address-book/personal',
+  },
+  {
+    path: '/strategy',
+    name: 'strategies',
+    icon: 'solution',
+    access: 'canAdmin',
+    component: './strategy',
+  },
+  {
+    path: '/custom-client',
+    name: 'customClients',
+    icon: 'form',
+    access: 'canAdmin',
+    component: './custom-client',
+  },
+  {
+    path: '/settings',
+    name: 'settings',
+    icon: 'setting',
+    access: 'canAdmin',
+    component: './settings',
+  },
+  {
     path: '/',
-    redirect: '/dashboard/workplace',
+    redirect: '/welcome',
   },
   {
     component: '404',

--- a/src/services/rustdesk-console/auth.ts
+++ b/src/services/rustdesk-console/auth.ts
@@ -15,3 +15,5 @@ export async function logout() {
 export async function currentUser() {
   return request<API.CurrentUser>('/api/currentUser', { method: 'POST' });
 }
+
+export const getCurrentUser = currentUser;

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -228,4 +228,122 @@ declare namespace API {
     max_peer_one_ab?: number;
     [key: string]: any;
   };
+
+  type SystemInfo = {
+    version?: string;
+    latestVersion?: string;
+    releaseUrl?: string;
+    [key: string]: any;
+  };
+
+  type LicenseInfo = {
+    currentDevices?: number;
+    maxDevices?: number | string;
+    expireTime?: string;
+    warning?: string;
+    [key: string]: any;
+  };
+
+  type RoleItem = {
+    guid: string;
+    name: string;
+    note?: string;
+    permission_count?: number;
+    created_at?: string;
+    updated_at?: string;
+    [key: string]: any;
+  };
+
+  type CreateRoleParams = {
+    name: string;
+    note?: string;
+    permissions?: string[];
+  };
+
+  type UpdateRoleParams = {
+    name?: string;
+    note?: string;
+    permissions?: string[];
+  };
+
+  type PermissionItem = {
+    id: string;
+    name: string;
+    description?: string;
+    module?: string;
+    [key: string]: any;
+  };
+
+  type StrategyItem = {
+    guid: string;
+    name: string;
+    note?: string;
+    status?: number;
+    rule_count?: number;
+    created_at?: string;
+    updated_at?: string;
+    [key: string]: any;
+  };
+
+  type CreateStrategyParams = {
+    name: string;
+    note?: string;
+    rules?: RuleItem[];
+  };
+
+  type UpdateStrategyParams = {
+    name?: string;
+    note?: string;
+    rules?: RuleItem[];
+    status?: number;
+  };
+
+  type UserGroupItem = {
+    guid: string;
+    name: string;
+    note?: string;
+    user_count?: number;
+    created_at?: string;
+    updated_at?: string;
+    [key: string]: any;
+  };
+
+  type CreateUserGroupParams = {
+    name: string;
+    note?: string;
+  };
+
+  type UpdateUserGroupParams = {
+    name?: string;
+    note?: string;
+  };
+
+  type CustomClientItem = {
+    guid: string;
+    name: string;
+    config?: Record<string, any>;
+    download_url?: string;
+    created_at?: string;
+    updated_at?: string;
+    [key: string]: any;
+  };
+
+  type CreateCustomClientParams = {
+    name: string;
+    config?: Record<string, any>;
+  };
+
+  type UpdateCustomClientParams = {
+    name?: string;
+    config?: Record<string, any>;
+  };
+
+  type SettingItem = {
+    key: string;
+    value: string | number | boolean;
+    type?: string;
+    description?: string;
+    category?: string;
+    [key: string]: any;
+  };
 }


### PR DESCRIPTION
This PR adds additional UI improvements that were missed in the previous PR:

## Changes
- Added routes for new pages (welcome, roles, strategies, settings, groups, custom-client)
- Added getCurrentUser export in auth service
- Extended type definitions for backend-supported features

## Type Definitions Added
- SystemInfo, LicenseInfo
- RoleItem, CreateRoleParams, UpdateRoleParams, PermissionItem
- StrategyItem, CreateStrategyParams, UpdateStrategyParams
- UserGroupItem, CreateUserGroupParams, UpdateUserGroupParams
- CustomClientItem, CreateCustomClientParams, UpdateCustomClientParams
- SettingItem

This is a continuation of the UI/UX improvements PR.