### PR TITLE
fix: unify table index column background color across all rows

### DIFF
--- a/src/global.less
+++ b/src/global.less
@@ -1,42 +1,42 @@
 @font-face {
+  font-weight: 300;
   font-family: "AlibabaSans";
   font-style: normal;
-  font-weight: 300;
-  font-display: swap;
   src: url("//mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*1GSgSYDD_aIAAAAAQsAAAAgAegCCAQ/AlibabaSans-Light.woff2")
     format("woff2");
+  font-display: swap;
 }
 @font-face {
+  font-weight: 400;
   font-family: "AlibabaSans";
   font-style: normal;
-  font-weight: 400;
-  font-display: swap;
   src: url("//mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*2zEUQqnPNesAAAAAQtAAAAgAegCCAQ/AlibabaSans-Regular.woff2")
     format("woff2");
+  font-display: swap;
 }
 @font-face {
+  font-weight: 500;
   font-family: "AlibabaSans";
   font-style: normal;
-  font-weight: 500;
-  font-display: swap;
   src: url("//mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*E_cxRbMlZqUAAAAAQuAAAAgAegCCAQ/AlibabaSans-Medium.woff2")
     format("woff2");
+  font-display: swap;
 }
 @font-face {
+  font-weight: 600;
   font-family: "AlibabaSans";
   font-style: normal;
-  font-weight: 600;
-  font-display: swap;
   src: url("//mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*E_cxRbMlZqUAAAAAQuAAAAgAegCCAQ/AlibabaSans-Bold.woff2")
     format("woff2");
+  font-display: swap;
 }
 @font-face {
+  font-weight: 700;
   font-family: "AlibabaSans";
   font-style: normal;
-  font-weight: 700;
-  font-display: swap;
   src: url("//mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*E_cxRbMlZqUAAAAAQuAAAAgAegCCAQ/AlibabaSans-Heavy.woff2")
     format("woff2");
+  font-display: swap;
 }
 
 html,
@@ -45,9 +45,9 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family:
-    AlibabaSans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
-    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family: AlibabaSans, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 .colorWeak {
@@ -91,4 +91,9 @@ ol {
       }
     }
   }
+}
+
+.ant-pro-field-index-column-border {
+  color: #fff !important;
+  background-color: rgb(49, 70, 89) !important;
 }


### PR DESCRIPTION
## Problem

ProComponents adds a `top-three` class to index column cells for row numbers greater than 3. This class applies a light gray background (`rgb(151, 151, 151)`), making indices 4+ appear washed out compared to indices 1-3 which have the dark theme background (`rgb(49, 70, 89)`).

## Solution

Added a global CSS override in `src/global.less` that forces consistent background color (`rgb(49, 70, 89)`) and white text for all index column cells, regardless of the `top-three` class.

## Root Cause

Investigated with Playwright by:
1. Inspecting DOM structure of table cells
2. Comparing computed styles between first 3 and subsequent rows
3. Found the CSS rule: `.ant-pro-field-index-column-border.top-three { background-color: rgb(151, 151, 151); }` added by ProComponents