### PR TITLE
fix: align API request formats with backend specifications

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -361,6 +361,9 @@ const PersonalAddressBook: React.FC = () => {
           <Form.Item name="hostname" label={<FormattedMessage id="pages.addressBook.device" defaultMessage="Device" />}>
             <Input disabled={!!selectedPeerId} />
           </Form.Item>
+          <Form.Item name="alias" label={<FormattedMessage id="pages.addressBook.alias" defaultMessage="Alias" />}>
+            <Input />
+          </Form.Item>
           <Form.Item name="note" label={<FormattedMessage id="pages.addressBook.note" defaultMessage="Note" />}>
             <Input.TextArea />
           </Form.Item>

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -137,16 +137,22 @@ declare namespace API {
 
   type AddPeerParams = {
     id: string;
+    alias?: string;
+    hash?: string;
+    password?: string;
     hostname?: string;
-    os?: string;
+    platform?: string;
     note?: string;
     tags?: string[];
   };
 
   type UpdatePeerParams = {
     id?: string;
+    alias?: string;
+    hash?: string;
+    password?: string;
     hostname?: string;
-    os?: string;
+    platform?: string;
     note?: string;
     tags?: string[];
   };
@@ -162,8 +168,8 @@ declare namespace API {
   };
 
   type RenameTagParams = {
-    name: string;
-    newName: string;
+    old: string;
+    new: string;
   };
 
   type UpdateTagParams = {
@@ -178,12 +184,15 @@ declare namespace API {
   };
 
   type CreateRuleParams = {
-    name: string;
-    [key: string]: any;
+    guid: string;
+    user?: string;
+    group?: string;
+    rule?: number;
   };
 
   type UpdateRuleParams = {
-    [key: string]: any;
+    guid: string;
+    rule: number;
   };
 
   type ConnectionAuditItem = {


### PR DESCRIPTION
## Summary
Fix API request formats to match backend DTO specifications

## Changes

### 1. AddPeerParams / UpdatePeerParams (typings.d.ts)
**Before:**
```typescript
{ id, hostname?, os?, note?, tags? }
```

**After:**
```typescript
{ id, alias?, hash?, password?, hostname?, platform?, note?, tags? }
```

Matches backend `AddPeerDto`:
- Added `alias` field for device alias
- Added `hash` field for connection hash (personal address book)
- Added `password` field for connection password (shared address book)
- Changed `os` to `platform` to match backend

### 2. RenameTagParams (typings.d.ts) - **Critical Fix**
**Before:** `{ name, newName }`
**After:** `{ old, new }`

Backend expects `old` and `new` field names, not `name` and `newName`

### 3. CreateRuleParams / UpdateRuleParams (typings.d.ts)
**Before:** Generic types with index signature
**After:** 
```typescript
CreateRuleParams: { guid, user?, group?, rule? }
UpdateRuleParams: { guid, rule: number }
```

Added required `guid` field that was missing

### 4. Personal Address Book Form (personal/index.tsx)
- Added `alias` input field to add peer form

## Files Modified
- `src/services/rustdesk-console/typings.d.ts` - Type definitions
- `src/pages/address-book/personal/index.tsx` - Add peer form

## Backend API Reference
Based on updated backend DTOs in:
- `src/modules/address-book/dto/peer.dto.ts`
- `src/modules/address-book/dto/tag.dto.ts`
- `src/modules/address-book/dto/rule.dto.ts`