### PR TITLE
feat(devices): 完善设备列表查询参数功能

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -70,6 +70,8 @@ export default {
   'pages.devices.device': 'Device',
   'pages.devices.strategy': 'Strategy',
   'pages.devices.info': 'Info',
+  'pages.devices.search': 'Search',
+  'pages.devices.searchPlaceholder': 'Search by ID, hostname, username...',
   'pages.addressBook.name': 'Name',
   'pages.addressBook.note': 'Note',
   'pages.addressBook.peerCount': 'Peer Count',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -69,6 +69,8 @@ export default {
   'pages.devices.device': '设备',
   'pages.devices.strategy': '策略',
   'pages.devices.info': '信息',
+  'pages.devices.search': '搜索',
+  'pages.devices.searchPlaceholder': '搜索ID、主机名、用户名...',
   'pages.addressBook.name': '名称',
   'pages.addressBook.note': '备注',
   'pages.addressBook.peerCount': '设备数',

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -89,7 +89,11 @@ const DeviceList: React.FC = () => {
   };
 
   const handleSearch = (values: { search?: string; status?: string }) => {
-    setSearchParams(values);
+    const params = {
+      search: values.search,
+      status: values.status && values.status !== 'all' ? values.status : undefined,
+    };
+    setSearchParams(params);
     actionRef.current?.reload();
   };
 
@@ -106,6 +110,37 @@ const DeviceList: React.FC = () => {
       copyable: true,
       width: 150,
       ellipsis: true,
+    },
+    {
+      title: <FormattedMessage id="pages.devices.search" defaultMessage="Search" />,
+      dataIndex: 'search',
+      hideInTable: true,
+      fieldProps: {
+        placeholder: intl.formatMessage({
+          id: 'pages.devices.searchPlaceholder',
+          defaultMessage: 'Search by ID, hostname, username...',
+        }),
+      },
+    },
+    {
+      title: <FormattedMessage id="pages.devices.status" defaultMessage="Status" />,
+      dataIndex: 'status',
+      hideInTable: true,
+      valueType: 'select',
+      valueEnum: {
+        all: {
+          text: <FormattedMessage id="pages.devices.allStatus" defaultMessage="All" />,
+          status: 'Default',
+        },
+        online: {
+          text: <FormattedMessage id="pages.devices.online" defaultMessage="Online" />,
+          status: 'Success',
+        },
+        offline: {
+          text: <FormattedMessage id="pages.devices.offline" defaultMessage="Offline" />,
+          status: 'Default',
+        },
+      },
     },
     {
       title: (
@@ -252,7 +287,7 @@ const DeviceList: React.FC = () => {
         }
         actionRef={actionRef}
         rowKey="guid"
-        request={async (params) => {
+        request={async (params, sort, filter) => {
           const result = await getDeviceList({
             current: params.current || 1,
             pageSize: params.pageSize || 20,

--- a/src/services/rustdesk-console/device.ts
+++ b/src/services/rustdesk-console/device.ts
@@ -5,15 +5,17 @@ export async function getDeviceList(
     current?: number;
     pageSize?: number;
     search?: string;
+    status?: string;
   },
   options?: { [key: string]: any },
 ) {
   return request<API.PaginatedResult<API.DeviceItem>>('/api/devices', {
     method: 'GET',
     params: {
-      current: params.current || 1,
+      page: params.current || 1,
       pageSize: params.pageSize || 20,
       search: params.search,
+      status: params.status,
     },
     ...(options || {}),
   });


### PR DESCRIPTION
## Summary

- 添加状态筛选功能，支持按在线/离线状态过滤设备
- 添加搜索功能，支持按ID、主机名、用户名搜索设备
- 修正API调用参数，使用正确的`page`参数替代`current`
- 添加`status`参数到API请求中，实现状态过滤
- 完善中英文国际化翻译，添加搜索相关的翻译项

## Changes

### API Service (`src/services/rustdesk-console/device.ts`)
- 添加`status`参数支持
- 修正API参数映射：`current` → `page`

### Device List Page (`src/pages/devices/list/index.tsx`)
- 添加搜索输入框，支持关键词搜索
- 添加状态下拉选择框，支持全部/在线/离线筛选
- 优化搜索参数处理逻辑，过滤无效的status值

### Internationalization
- 添加搜索相关的中英文翻译
- `pages.devices.search`: 搜索
- `pages.devices.searchPlaceholder`: 搜索ID、主机名、用户名...

## Test Plan

- [ ] 测试搜索功能：输入关键词后能正确过滤设备列表
- [ ] 测试状态筛选：选择在线/离线状态后能正确显示对应设备
- [ ] 测试组合查询：同时使用搜索和状态筛选
- [ ] 测试重置功能：重置后能恢复显示所有设备
- [ ] 测试分页功能：查询结果分页正常工作
- [ ] 测试国际化：中英文切换后文本显示正确