### PR TITLE
refactor(address-book): remove Add Tag and Manage Tags toolbar buttons

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -574,12 +574,6 @@ const PersonalAddressBook: React.FC = () => {
           <Button key="recycle" icon={<DeleteOutlined />}>
             <FormattedMessage id="pages.addressBook.recycleBin" defaultMessage="Recycle Bin" />
           </Button>,
-          <Button key="addTag" icon={<TagOutlined />} onClick={() => setAddTagModalVisible(true)}>
-            <FormattedMessage id="pages.addressBook.addTag" defaultMessage="Add Tag" />
-          </Button>,
-          <Button key="manageTags" icon={<TagOutlined />} onClick={() => setTagManagementVisible(true)}>
-            <FormattedMessage id="pages.addressBook.manageTags" defaultMessage="Manage Tags" />
-          </Button>,
         ]}
         options={{
           density: true,


### PR DESCRIPTION
## Summary
- Remove Add Tag and Manage Tags buttons from the toolbar
- Tag management is now handled by the tags area above the table (added in PR #27)

## Test plan
- [ ] Verify Add Tag and Manage Tags buttons no longer appear in toolbar
- [ ] Verify tag management still works via tags area