### PR TITLE
refactor(address-book): remove index column from personal address book table

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -296,12 +296,6 @@ const PersonalAddressBook: React.FC = () => {
 
   const columns: ProColumns<API.PeerItem>[] = [
     {
-      title: "",
-      dataIndex: "index",
-      valueType: "indexBorder",
-      width: 50,
-    },
-    {
       title: "ID",
       dataIndex: "id",
       copyable: true,


### PR DESCRIPTION
## Summary
- Remove the sequential number (indexBorder) column from the personal address book peer table

## Test plan
- [ ] Verify the index column no longer appears in the table
- [ ] Verify other columns display correctly