### PR TITLE
style(address-book): change Action column to text links with separator

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -370,12 +370,11 @@ const PersonalAddressBook: React.FC = () => {
       width: 160,
       fixed: "right",
       render: (_: unknown, record: API.PeerItem) => (
-        <Space size="small">
+        <Space size="small" split={<span style={{ color: '#ccc' }}>|</span>}>
           <Button
             key="edit"
             type="link"
             size="small"
-            icon={<EditOutlined />}
             onClick={() => handleEditPeer(record)}
           >
             <FormattedMessage id="pages.common.edit" defaultMessage="Edit" />


### PR DESCRIPTION
## Summary
- Remove EditOutlined icon from Edit button in Action column
- Add pipe separator between Edit and Delete links

## Test plan
- [ ] Verify Edit button no longer has icon
- [ ] Verify pipe separator appears between Edit and Delete