### PR TITLE
refactor(address-book): simplify Edit peer modal

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -596,7 +596,7 @@ const PersonalAddressBook: React.FC = () => {
 
       {/* Edit Peer Modal */}
       <Modal
-        title={<FormattedMessage id="pages.addressBook.editPeer" defaultMessage="Edit Peer" />}
+        title={<FormattedMessage id="pages.common.edit" defaultMessage="Edit" />}
         open={editPeerModalVisible}
         onCancel={() => {
           setEditPeerModalVisible(false);
@@ -615,10 +615,7 @@ const PersonalAddressBook: React.FC = () => {
         )}
         <Form form={editPeerForm} onFinish={handleUpdatePeer} layout="vertical">
           <Form.Item name="id" label="ID">
-            <Input disabled />
-          </Form.Item>
-          <Form.Item name="hostname" label={<FormattedMessage id="pages.addressBook.device" defaultMessage="Device" />}>
-            <Input disabled />
+            <Text>{editingPeer?.id}</Text>
           </Form.Item>
           <Form.Item name="alias" label={<FormattedMessage id="pages.addressBook.alias" defaultMessage="Alias" />}>
             <Input />


### PR DESCRIPTION
## Summary
- Change Edit modal title from "Edit Peer" to "Edit"
- Display ID as plain text instead of disabled input
- Remove Device field from Edit modal

## Test plan
- [ ] Verify Edit modal title shows "Edit"
- [ ] Verify ID is displayed as plain text
- [ ] Verify Device field is removed