### PR TITLE
refactor(locale): rename Navigation Mode to Mix Menu Layout

### DIFF
--- a/src/locales/en-US/settingDrawer.ts
+++ b/src/locales/en-US/settingDrawer.ts
@@ -14,7 +14,7 @@ export default {
   'app.setting.themecolor.daybreak': 'Daybreak Blue (default)',
   'app.setting.themecolor.geekblue': 'Geek Glue',
   'app.setting.themecolor.purple': 'Golden Purple',
-  'app.setting.navigationmode': 'Navigation Mode',
+  'app.setting.navigationmode': 'Mix Menu Layout',
   'app.setting.sidemenu': 'Side Menu Layout',
   'app.setting.topmenu': 'Top Menu Layout',
   'app.setting.fixedheader': 'Fixed Header',

--- a/src/locales/zh-CN/settingDrawer.ts
+++ b/src/locales/zh-CN/settingDrawer.ts
@@ -14,7 +14,7 @@ export default {
   'app.setting.themecolor.daybreak': '拂晓蓝（默认）',
   'app.setting.themecolor.geekblue': '极客蓝',
   'app.setting.themecolor.purple': '酱紫',
-  'app.setting.navigationmode': '导航模式',
+  'app.setting.navigationmode': '混合菜单布局',
   'app.setting.sidemenu': '侧边菜单布局',
   'app.setting.topmenu': '顶部菜单布局',
   'app.setting.fixedheader': '固定 Header',


### PR DESCRIPTION
## Summary
- Rename the SettingDrawer label from "Navigation Mode" to "Mix Menu Layout" in the en-US locale
- Rename the corresponding label from "导航模式" to "混合菜单布局" in the zh-CN locale

## Test plan
- [ ] Verify the SettingDrawer displays "Mix Menu Layout" instead of "Navigation Mode" in English
- [ ] Verify the SettingDrawer displays "混合菜单布局" instead of "导航模式" in Chinese