### PR TITLE
feat(layout): change default navigation mode to mix

### DIFF
--- a/config/defaultSettings.ts
+++ b/config/defaultSettings.ts
@@ -6,7 +6,7 @@ const Settings: ProLayoutProps & {
 } = {
   navTheme: 'light',
   colorPrimary: '#1890ff',
-  layout: 'side',
+  layout: 'mix',
   contentWidth: 'Fluid',
   fixedHeader: true,
   fixSiderbar: true,


### PR DESCRIPTION
## Summary
- Change default layout from `side` (side menu) to `mix` (mix menu layout) in `config/defaultSettings.ts`
- Mix layout combines top navigation bar with side menu, providing better navigation experience

## Test plan
- [ ] Verify the application loads with mix menu layout by default
- [ ] Verify top navigation and side menu both render correctly
- [ ] Verify SettingDrawer still allows switching between layout modes