### PR TITLE
feat(address-book): add tag color dot with hover color picker and delete confirmation

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -90,6 +90,7 @@ export default {
   'pages.addressBook.tagAddFailed': 'Failed to add tag',
   'pages.addressBook.tagDeleted': 'Tag deleted',
   'pages.addressBook.tagDeleteFailed': 'Failed to delete tag',
+  'pages.addressBook.deleteTagConfirm': 'Are you sure to delete this tag?',
   'pages.addressBook.createSuccess': 'Address book created',
   'pages.addressBook.createFailed': 'Failed to create address book',
   'pages.addressBook.updateSuccess': 'Address book updated',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -89,6 +89,7 @@ export default {
   'pages.addressBook.tagAddFailed': '添加标签失败',
   'pages.addressBook.tagDeleted': '标签已删除',
   'pages.addressBook.tagDeleteFailed': '删除标签失败',
+  'pages.addressBook.deleteTagConfirm': '确定要删除此标签吗？',
   'pages.addressBook.createSuccess': '地址簿已创建',
   'pages.addressBook.createFailed': '创建地址簿失败',
   'pages.addressBook.updateSuccess': '地址簿已更新',

--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -1,8 +1,8 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Select, Space, Tag, Table, Typography } from 'antd';
-import { CloseOutlined, DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, SelectOutlined, TagOutlined } from '@ant-design/icons';
+import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Select, Space, Tag, Table, Tooltip, Typography } from 'antd';
+import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, SelectOutlined } from '@ant-design/icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getPersonalAddressBook,
@@ -459,25 +459,82 @@ const PersonalAddressBook: React.FC = () => {
         >
           Untagged
         </Tag>
-        {(tags as API.TagItem[]).map((tag: API.TagItem) => (
-          <Tag
-            key={tag.name}
-            color={selectedTag === tag.name ? argbToHex(tag.color) : undefined}
-            style={{ cursor: 'pointer', padding: '2px 8px' }}
-            closeIcon={<CloseOutlined style={{ fontSize: 10, marginLeft: 2 }} />}
-            closable
-            onClose={(e) => {
-              e.preventDefault();
-              handleDeleteTag(tag.name);
-            }}
-            onClick={() => {
-              setSelectedTag(selectedTag === tag.name ? null : tag.name);
-              actionRef.current?.reload();
-            }}
-          >
-            {tag.name}
-          </Tag>
-        ))}
+        {(tags as API.TagItem[]).map((tag: API.TagItem) => {
+          const tagColor = argbToHex(tag.color);
+          return (
+            <Tag
+              key={tag.name}
+              color={selectedTag === tag.name ? tagColor : undefined}
+              style={{ cursor: 'pointer', padding: '2px 8px', paddingLeft: 0 }}
+              closable
+              closeIcon={
+                <Popconfirm
+                  title={
+                    <FormattedMessage
+                      id="pages.addressBook.deleteTagConfirm"
+                      defaultMessage="Are you sure to delete this tag?"
+                    />
+                  }
+                  onConfirm={(e) => {
+                    e?.stopPropagation();
+                    handleDeleteTag(tag.name);
+                  }}
+                  onCancel={(e) => {
+                    e?.stopPropagation();
+                  }}
+                >
+                  <span
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ marginLeft: 4, cursor: 'pointer' }}
+                  >
+                    ×
+                  </span>
+                </Popconfirm>
+              }
+              onClose={(e) => {
+                e.preventDefault();
+              }}
+              onClick={() => {
+                setSelectedTag(selectedTag === tag.name ? null : tag.name);
+                actionRef.current?.reload();
+              }}
+            >
+              <span style={{ paddingLeft: 6, display: 'inline-flex', alignItems: 'center' }}>
+                <Tooltip
+                  trigger="hover"
+                  color="transparent"
+                  styles={{ inner: { padding: 0 } }}
+                  title={
+                    <div style={{ background: '#fff', borderRadius: 8, boxShadow: '0 6px 16px 0 rgba(0,0,0,.08), 0 3px 6px -4px rgba(0,0,0,.12), 0 9px 28px 8px rgba(0,0,0,.05)' }}>
+                      <ColorPicker
+                        disabledAlpha
+                        value={tagColor}
+                        onChangeComplete={(colorValue) => {
+                          const rgb = colorValue.toRgb();
+                          const newArgb = 0xFF000000 + (rgb.r << 16) + (rgb.g << 8) + rgb.b;
+                          handleUpdateTagColor(tag.name, newArgb);
+                        }}
+                      />
+                    </div>
+                  }
+                >
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor: tagColor,
+                      cursor: 'pointer',
+                    }}
+                  />
+                </Tooltip>
+                <span style={{ display: 'inline-block', width: 8 }} />
+              </span>
+              {tag.name}
+            </Tag>
+          );
+        })}
         <Button
           size="small"
           type="dashed"


### PR DESCRIPTION
## Summary

- Add color dot (8px circle) inside each tag in the personal address book tags area, matching the reference RustDesk Server Pro UI
- Show ColorPicker panel on hover over the color dot, with `disabledAlpha` to exclude opacity/alpha slider
- Replace direct tag deletion with Popconfirm for two-step delete confirmation
- Add i18n keys (`pages.addressBook.deleteTagConfirm`) for both en-US and zh-CN

## Changes

- `src/pages/address-book/personal/index.tsx`: Refactored tag rendering in the tags area to include a color dot with Tooltip-wrapped ColorPicker, and Popconfirm for delete
- `src/locales/en-US/pages.ts`: Added `pages.addressBook.deleteTagConfirm` key
- `src/locales/zh-CN/pages.ts`: Added `pages.addressBook.deleteTagConfirm` key

## Test plan

- [ ] Verify each tag in the personal address book shows a colored dot (8px circle) before the tag name
- [ ] Hover over the color dot and confirm the ColorPicker panel appears without alpha/opacity slider
- [ ] Change a tag color via the hover ColorPicker and verify the color updates correctly
- [ ] Click the close (×) icon on a tag and confirm a Popconfirm dialog appears before deletion
- [ ] Confirm the tag is only deleted after clicking "OK" in the confirmation dialog
- [ ] Verify i18n works correctly for both en-US and zh-CN locales