### PR TITLE
feat(address-book): support multi-tag filtering with union/intersection mode

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -91,6 +91,8 @@ export default {
   'pages.addressBook.tagDeleted': 'Tag deleted',
   'pages.addressBook.tagDeleteFailed': 'Failed to delete tag',
   'pages.addressBook.deleteTagConfirm': 'Are you sure to delete this tag?',
+  'pages.addressBook.tagModeUnion': 'Any',
+  'pages.addressBook.tagModeIntersection': 'All',
   'pages.addressBook.createSuccess': 'Address book created',
   'pages.addressBook.createFailed': 'Failed to create address book',
   'pages.addressBook.updateSuccess': 'Address book updated',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -90,6 +90,8 @@ export default {
   'pages.addressBook.tagDeleted': '标签已删除',
   'pages.addressBook.tagDeleteFailed': '删除标签失败',
   'pages.addressBook.deleteTagConfirm': '确定要删除此标签吗？',
+  'pages.addressBook.tagModeUnion': '任一',
+  'pages.addressBook.tagModeIntersection': '全部',
   'pages.addressBook.createSuccess': '地址簿已创建',
   'pages.addressBook.createFailed': '创建地址簿失败',
   'pages.addressBook.updateSuccess': '地址簿已更新',

--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Select, Space, Tag, Table, Typography } from 'antd';
+import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Radio, Select, Space, Tag, Table, Typography } from 'antd';
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, SelectOutlined } from '@ant-design/icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -48,7 +48,8 @@ const PersonalAddressBook: React.FC = () => {
   const [abLoading, setAbLoading] = useState(true);
   const [tags, setTags] = useState<API.TagItem[]>([]);
   const [pendingColorUpdates, setPendingColorUpdates] = useState<Record<string, number>>({});
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagMode, setTagMode] = useState<'union' | 'intersection'>('union');
   const [hoveredColorDot, setHoveredColorDot] = useState<string | null>(null);
   
   
@@ -455,14 +456,14 @@ const PersonalAddressBook: React.FC = () => {
         </span>
         <Tag
           style={{ cursor: 'pointer', padding: '2px 8px' }}
-          color={selectedTag === null ? 'blue' : undefined}
-          onClick={() => { setSelectedTag(null); actionRef.current?.reload(); }}
+          color={selectedTags.length === 0 ? 'blue' : undefined}
+          onClick={() => { setSelectedTags([]); actionRef.current?.reload(); }}
         >
           Untagged
         </Tag>
         {(tags as API.TagItem[]).map((tag: API.TagItem) => {
           const displayColor = argbToHex(pendingColorUpdates[tag.name] ?? tag.color);
-          const isSelected = selectedTag === tag.name;
+          const isSelected = selectedTags.includes(tag.name);
           return (
             <Tag
               key={tag.name}
@@ -501,7 +502,9 @@ const PersonalAddressBook: React.FC = () => {
                 e.preventDefault();
               }}
               onClick={() => {
-                setSelectedTag(isSelected ? null : tag.name);
+                setSelectedTags(prev =>
+                  isSelected ? prev.filter(t => t !== tag.name) : [...prev, tag.name]
+                );
                 actionRef.current?.reload();
               }}
             >
@@ -550,6 +553,25 @@ const PersonalAddressBook: React.FC = () => {
           icon={<PlusOutlined />}
           onClick={() => setAddTagModalVisible(true)}
         />
+        {selectedTags.length > 1 && (
+          <Radio.Group
+            size="small"
+            value={tagMode}
+            onChange={(e) => {
+              setTagMode(e.target.value);
+              actionRef.current?.reload();
+            }}
+            optionType="button"
+            buttonStyle="solid"
+          >
+            <Radio.Button value="union">
+              <FormattedMessage id="pages.addressBook.tagModeUnion" defaultMessage="Any" />
+            </Radio.Button>
+            <Radio.Button value="intersection">
+              <FormattedMessage id="pages.addressBook.tagModeIntersection" defaultMessage="All" />
+            </Radio.Button>
+          </Radio.Group>
+        )}
       </div>
 
       <ProTable<API.PeerItem>
@@ -568,7 +590,8 @@ const PersonalAddressBook: React.FC = () => {
             pageSize: params.pageSize || 20,
             ab: abGuid,
             id: params.id,
-            tags: selectedTag ? [selectedTag] : undefined,
+            tags: selectedTags.length > 0 ? selectedTags : undefined,
+            tagMode: selectedTags.length > 1 ? tagMode : undefined,
           });
           return {
             data: result.data || [],

--- a/src/services/rustdesk-console/addressBook.ts
+++ b/src/services/rustdesk-console/addressBook.ts
@@ -46,6 +46,8 @@ export async function getPeers(
     ab?: string;
     id?: string;
     alias?: string;
+    tags?: string[];
+    tagMode?: 'union' | 'intersection';
   },
 ) {
   return request<API.PaginatedResult<API.PeerItem>>('/api/ab/peers', {


### PR DESCRIPTION
## Summary

- Support selecting multiple tags for filtering (was single-tag only)
- Add tagMode toggle (union/intersection) that appears when 2+ tags are selected
  - **Union (Any)**: match peers that have ANY of the selected tags (OR)
  - **Intersection (All)**: match peers that have ALL of the selected tags (AND)
- Pass `tags` array and `tagMode` parameter to `/api/ab/peers` API
- Add i18n keys for tagMode labels

## Changes

- `src/services/rustdesk-console/addressBook.ts`: Add `tags` and `tagMode` params to `getPeers`
- `src/pages/address-book/personal/index.tsx`:
  - Change `selectedTag` (string|null) to `selectedTags` (string[])
  - Add `tagMode` state with Radio.Group toggle
  - Pass `tags` and `tagMode` to API request
- `src/locales/en-US/pages.ts`: Add `tagModeUnion`/`tagModeIntersection` keys
- `src/locales/zh-CN/pages.ts`: Add `tagModeUnion`/`tagModeIntersection` keys

## Test plan

- [ ] Click a single tag — peers filtered by that tag
- [ ] Click a second tag — both tags highlighted, tagMode toggle appears
- [ ] With tagMode "Any" (union) — shows peers matching either tag
- [ ] With tagMode "All" (intersection) — shows peers matching both tags
- [ ] Click a selected tag to deselect it
- [ ] Click "Untagged" to clear all tag filters
- [ ] Verify i18n for both en-US and zh-CN locales