### PR TITLE
fix(address-book): serialize tags as repeated query params

### DIFF
--- a/src/services/rustdesk-console/addressBook.ts
+++ b/src/services/rustdesk-console/addressBook.ts
@@ -50,9 +50,25 @@ export async function getPeers(
     tagMode?: 'union' | 'intersection';
   },
 ) {
-  return request<API.PaginatedResult<API.PeerItem>>('/api/ab/peers', {
+  const { tags, tagMode, ...restParams } = params;
+  let url = '/api/ab/peers';
+  const searchParams = new URLSearchParams();
+
+  if (tags && tags.length > 0) {
+    tags.forEach(tag => searchParams.append('tags', tag));
+  }
+  if (tags && tags.length > 1 && tagMode) {
+    searchParams.set('tagMode', tagMode);
+  }
+
+  const queryString = searchParams.toString();
+  if (queryString) {
+    url += `?${queryString}`;
+  }
+
+  return request<API.PaginatedResult<API.PeerItem>>(url, {
     method: 'GET',
-    params,
+    params: restParams,
   });
 }
 


### PR DESCRIPTION
## Summary

Fix the query parameter serialization for the `tags` array in `/api/ab/peers` requests.

**Before:** `tags[]=a&tags[]=b` (umi/qs default array format)
**After:** `tags=a&tags=b` (repeated key format expected by backend)

## Changes

- `src/services/rustdesk-console/addressBook.ts`: Use `URLSearchParams.append()` to manually build the `tags` and `tagMode` query string, then pass remaining params separately to avoid umi's default array serialization.

## Example

```
# Single tag
/api/ab/peers?tags=server&current=1&pageSize=20&ab=xxx

# Multiple tags with tagMode
/api/ab/peers?tags=server&tags=prod&tagMode=union&current=1&pageSize=20&ab=xxx
```

## Test plan

- [ ] Select one tag — verify request sends `tags=xxx` (not `tags[]=xxx`)
- [ ] Select two tags — verify request sends `tags=a&tags=b`
- [ ] Select two tags with intersection mode — verify `tags=a&tags=b&tagMode=intersection`
- [ ] Clear tag selection — verify no `tags` param in request