### PR TITLE
fix(address-book): auto-close color picker when mouse leaves dot or panel

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -515,12 +515,7 @@ const PersonalAddressBook: React.FC = () => {
                   value={displayColor}
                   open={hoveredColorDot === tag.name}
                   onOpenChange={(open) => {
-                    if (open) {
-                      if (colorPickerCloseTimerRef.current) {
-                        clearTimeout(colorPickerCloseTimerRef.current);
-                        colorPickerCloseTimerRef.current = null;
-                      }
-                    } else {
+                    if (!open) {
                       setHoveredColorDot(null);
                     }
                   }}
@@ -534,6 +529,23 @@ const PersonalAddressBook: React.FC = () => {
                     const newArgb = 0xFF000000 + (rgb.r << 16) + (rgb.g << 8) + rgb.b;
                     handleUpdateTagColor(tag.name, newArgb);
                   }}
+                  panelRender={(panel) => (
+                    <div
+                      onMouseEnter={() => {
+                        if (colorPickerCloseTimerRef.current) {
+                          clearTimeout(colorPickerCloseTimerRef.current);
+                          colorPickerCloseTimerRef.current = null;
+                        }
+                      }}
+                      onMouseLeave={() => {
+                        colorPickerCloseTimerRef.current = setTimeout(() => {
+                          setHoveredColorDot(null);
+                        }, 100);
+                      }}
+                    >
+                      {panel}
+                    </div>
+                  )}
                 >
                   <span
                     onMouseEnter={() => {

--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -51,6 +51,7 @@ const PersonalAddressBook: React.FC = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagMode, setTagMode] = useState<'union' | 'intersection'>('union');
   const [hoveredColorDot, setHoveredColorDot] = useState<string | null>(null);
+  const colorPickerCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   
   useEffect(() => {
@@ -514,7 +515,12 @@ const PersonalAddressBook: React.FC = () => {
                   value={displayColor}
                   open={hoveredColorDot === tag.name}
                   onOpenChange={(open) => {
-                    if (!open) {
+                    if (open) {
+                      if (colorPickerCloseTimerRef.current) {
+                        clearTimeout(colorPickerCloseTimerRef.current);
+                        colorPickerCloseTimerRef.current = null;
+                      }
+                    } else {
                       setHoveredColorDot(null);
                     }
                   }}
@@ -530,7 +536,18 @@ const PersonalAddressBook: React.FC = () => {
                   }}
                 >
                   <span
-                    onMouseEnter={() => setHoveredColorDot(tag.name)}
+                    onMouseEnter={() => {
+                      if (colorPickerCloseTimerRef.current) {
+                        clearTimeout(colorPickerCloseTimerRef.current);
+                        colorPickerCloseTimerRef.current = null;
+                      }
+                      setHoveredColorDot(tag.name);
+                    }}
+                    onMouseLeave={() => {
+                      colorPickerCloseTimerRef.current = setTimeout(() => {
+                        setHoveredColorDot(null);
+                      }, 100);
+                    }}
                     style={{
                       display: 'inline-block',
                       width: 8,


### PR DESCRIPTION
## Summary

Fix the color picker panel to automatically close when the mouse leaves both the color dot and the panel.

**Before:** Panel stays open indefinitely after hovering the dot; only closes on explicit click outside.
**After:** Panel closes automatically 100ms after mouse leaves the dot, unless the mouse enters the panel (or re-enters the dot) within that delay.

## Changes

- `src/pages/address-book/personal/index.tsx`:
  - Add `colorPickerCloseTimerRef` to track delayed close
  - On `onMouseLeave` from the dot: start 100ms delayed close
  - On `onMouseEnter` to the dot: cancel any pending close
  - On `onOpenChange(true)` (mouse enters panel): cancel any pending close

## Test plan

- [ ] Hover over color dot — panel opens
- [ ] Move mouse away from dot (not into panel) — panel closes after short delay
- [ ] Hover dot, move mouse into panel — panel stays open
- [ ] Move mouse out of panel (not back to dot) — panel closes
- [ ] Quickly move mouse out and back to dot — panel stays open (close cancelled)