### PR TITLE
feat(devices): enhance device table with OS icons and improved column layout

### DIFF
--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -18,7 +18,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: 'ID',
       dataIndex: 'id',
-      width: '12%',
+      width: '15%',
       ellipsis: true,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => (
@@ -39,7 +39,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
         </span>
       ),
       dataIndex: 'device_name',
-      width: '18%',
       ellipsis: true,
       search: false,
       sorter: true,
@@ -53,7 +52,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.deviceGroup" defaultMessage="Group" />,
       dataIndex: 'device_group_name',
-      width: '10%',
       ellipsis: true,
       hideInSearch: true,
       sorter: true,
@@ -62,7 +60,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.user" defaultMessage="User" />,
       dataIndex: 'user_name',
-      width: '10%',
       ellipsis: true,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => record.user_name || '-',
@@ -103,7 +100,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.status" defaultMessage="Status" />,
       dataIndex: 'status_display',
-      width: '6%',
       search: false,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => {
@@ -123,7 +119,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
         </span>
       ),
       dataIndex: 'strategy_name',
-      width: '10%',
       ellipsis: true,
       search: false,
       render: (_: unknown, record: API.DeviceItem) => record.strategy_name || '-',
@@ -131,7 +126,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.info" defaultMessage="Info" />,
       dataIndex: 'info',
-      width: '18%',
       ellipsis: true,
       search: false,
       render: (_: unknown, record: API.DeviceItem) => {
@@ -142,7 +136,6 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.note" defaultMessage="Note" />,
       dataIndex: 'note',
-      width: '16%',
       ellipsis: true,
       search: false,
       sorter: true,

--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -105,7 +105,17 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
             </Tooltip>
             &nbsp;&nbsp;
             {osIcon && osTooltip && (
-              <Tooltip title={osTooltip}>
+              <Tooltip 
+                title={osTooltip}
+                styles={{
+                  root: {
+                    maxWidth: 'none',
+                  },
+                }}
+                overlayStyle={{
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 {osIcon}
               </Tooltip>
             )}

--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -18,7 +18,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: 'ID',
       dataIndex: 'id',
-      width: '15%',
+      width: '12%',
       ellipsis: true,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => (
@@ -39,7 +39,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
         </span>
       ),
       dataIndex: 'device_name',
-      width: 150,
+      width: '18%',
       ellipsis: true,
       search: false,
       sorter: true,
@@ -53,7 +53,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.deviceGroup" defaultMessage="Group" />,
       dataIndex: 'device_group_name',
-      width: 120,
+      width: '10%',
       ellipsis: true,
       hideInSearch: true,
       sorter: true,
@@ -62,7 +62,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.user" defaultMessage="User" />,
       dataIndex: 'user_name',
-      width: 120,
+      width: '10%',
       ellipsis: true,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => record.user_name || '-',
@@ -103,7 +103,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.status" defaultMessage="Status" />,
       dataIndex: 'status_display',
-      width: 80,
+      width: '6%',
       search: false,
       sorter: true,
       render: (_: unknown, record: API.DeviceItem) => {
@@ -123,7 +123,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
         </span>
       ),
       dataIndex: 'strategy_name',
-      width: 100,
+      width: '10%',
       ellipsis: true,
       search: false,
       render: (_: unknown, record: API.DeviceItem) => record.strategy_name || '-',
@@ -131,7 +131,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.info" defaultMessage="Info" />,
       dataIndex: 'info',
-      width: 200,
+      width: '18%',
       ellipsis: true,
       search: false,
       render: (_: unknown, record: API.DeviceItem) => {
@@ -142,7 +142,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
     {
       title: <FormattedMessage id="pages.devices.note" defaultMessage="Note" />,
       dataIndex: 'note',
-      width: 150,
+      width: '16%',
       ellipsis: true,
       search: false,
       sorter: true,

--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -8,6 +8,7 @@ import {
   WindowsFilled,
   AndroidFilled,
   AppleFilled,
+  QqCircleFilled,
 } from '@ant-design/icons';
 import React from 'react';
 
@@ -58,8 +59,7 @@ const getOSIcon = (os: string): React.ReactNode => {
     return <AppleFilled />;
   }
   if (osLower.includes('linux')) {
-    // Using a generic icon for Linux since there's no specific Linux icon
-    return <span style={{ fontSize: '14px' }}>🐧</span>;
+    return <QqCircleFilled />;
   }
   
   return null;
@@ -95,14 +95,17 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
           onlineTooltip = `${intl.formatMessage({ id: 'pages.devices.offline', defaultMessage: 'Offline' })}${offlineDuration}`;
         }
         
+        // Build OS tooltip - show full OS info in one line
+        const osTooltip = osParts[1] || osParts[0] || '';
+        
         return (
           <span>
             <Tooltip title={onlineTooltip}>
               <Badge status={record.is_online ? 'success' : 'error'} />
             </Tooltip>
             &nbsp;&nbsp;
-            {osIcon && (
-              <Tooltip title={osParts[1] || osParts[0]}>
+            {osIcon && osTooltip && (
+              <Tooltip title={osTooltip}>
                 {osIcon}
               </Tooltip>
             )}

--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -101,7 +101,9 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
         return (
           <span>
             <Tooltip title={onlineTooltip}>
-              <Badge status={record.is_online ? 'success' : 'error'} />
+              <span>
+                <Badge status={record.is_online ? 'success' : 'error'} />
+              </span>
             </Tooltip>
             &nbsp;&nbsp;
             {osIcon && osTooltip && (
@@ -116,7 +118,7 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
                   whiteSpace: 'nowrap',
                 }}
               >
-                {osIcon}
+                <span>{osIcon}</span>
               </Tooltip>
             )}
             {osIcon && <>&nbsp;&nbsp;</>}

--- a/src/components/DeviceSelectTable/columns.tsx
+++ b/src/components/DeviceSelectTable/columns.tsx
@@ -1,8 +1,69 @@
 import type { ProColumns } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
 import { Badge, Tooltip } from 'antd';
-import { CheckCircleOutlined, CloseCircleOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { 
+  CheckCircleOutlined, 
+  CloseCircleOutlined, 
+  InfoCircleOutlined,
+  WindowsFilled,
+  AndroidFilled,
+  AppleFilled,
+} from '@ant-design/icons';
 import React from 'react';
+
+/**
+ * Get offline duration text
+ */
+const getOfflineDuration = (lastOnlineTime: string, intl: any): string => {
+  try {
+    const lastOnline = new Date(lastOnlineTime + (lastOnlineTime.endsWith('Z') ? '' : 'Z'));
+    const now = new Date();
+    const diffMs = now.getTime() - lastOnline.getTime();
+
+    if (diffMs > 0) {
+      const diffMinutes = Math.floor(diffMs / (1000 * 60));
+      const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+      if (diffDays > 0) {
+        return ` (${diffDays} ${intl.formatMessage({ id: 'pages.devices.days', defaultMessage: 'days' })})`;
+      } else if (diffHours > 0) {
+        return ` (${diffHours} ${intl.formatMessage({ id: 'pages.devices.hours', defaultMessage: 'hours' })})`;
+      } else if (diffMinutes > 0) {
+        return ` (${diffMinutes} ${intl.formatMessage({ id: 'pages.devices.minutes', defaultMessage: 'minutes' })})`;
+      } else {
+        return ` (${intl.formatMessage({ id: 'pages.devices.justNow', defaultMessage: 'just now' })})`;
+      }
+    } else {
+      return '';
+    }
+  } catch (error) {
+    return '';
+  }
+};
+
+/**
+ * Get OS icon component
+ */
+const getOSIcon = (os: string): React.ReactNode => {
+  const osLower = (os || '').toLowerCase();
+  
+  if (osLower.includes('windows')) {
+    return <WindowsFilled />;
+  }
+  if (osLower.includes('android')) {
+    return <AndroidFilled />;
+  }
+  if (osLower.includes('macos') || osLower.includes('ios') || osLower.includes('mac')) {
+    return <AppleFilled />;
+  }
+  if (osLower.includes('linux')) {
+    // Using a generic icon for Linux since there's no specific Linux icon
+    return <span style={{ fontSize: '14px' }}>🐧</span>;
+  }
+  
+  return null;
+};
 
 /**
  * Get device table columns definition
@@ -21,13 +82,35 @@ export const getDeviceColumns = (options?: { hideAction?: boolean }): ProColumns
       width: '15%',
       ellipsis: true,
       sorter: true,
-      render: (_: unknown, record: API.DeviceItem) => (
-        <span>
-          <Badge status={record.is_online ? 'success' : 'error'} />
-          &nbsp;&nbsp;
-          <a>{record.id}</a>
-        </span>
-      ),
+      render: (_: unknown, record: API.DeviceItem) => {
+        const osParts = (record.info?.os || '').split(' / ');
+        const osIcon = getOSIcon(record.info?.os || '');
+        
+        // Build online status tooltip
+        let onlineTooltip: string;
+        if (record.is_online) {
+          onlineTooltip = intl.formatMessage({ id: 'pages.devices.online', defaultMessage: 'Online' });
+        } else {
+          const offlineDuration = record.last_online ? getOfflineDuration(record.last_online, intl) : '';
+          onlineTooltip = `${intl.formatMessage({ id: 'pages.devices.offline', defaultMessage: 'Offline' })}${offlineDuration}`;
+        }
+        
+        return (
+          <span>
+            <Tooltip title={onlineTooltip}>
+              <Badge status={record.is_online ? 'success' : 'error'} />
+            </Tooltip>
+            &nbsp;&nbsp;
+            {osIcon && (
+              <Tooltip title={osParts[1] || osParts[0]}>
+                {osIcon}
+              </Tooltip>
+            )}
+            {osIcon && <>&nbsp;&nbsp;</>}
+            <a>{record.id}</a>
+          </span>
+        );
+      },
     },
     {
       title: (

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -48,7 +48,7 @@ export default {
   'pages.devices.os': 'OS',
   'pages.devices.status': 'Status',
   'pages.devices.user': 'User',
-  'pages.devices.deviceGroup': 'Device Group',
+  'pages.devices.deviceGroup': 'Group',
   'pages.devices.lastOnline': 'Last Online',
   'pages.devices.note': 'Note',
   'pages.devices.online': 'Online',

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -188,7 +188,8 @@ const DeviceList: React.FC = () => {
           showSizeChanger: true,
           showQuickJumper: true,
         }}
-        scroll={{ x: 1400 }}
+        resizable
+        scroll={{ x: '100%' }}
         toolBarRender={false}
         options={{
           density: true,


### PR DESCRIPTION
## Summary
This PR enhances the device table with several improvements for better user experience and visual consistency.

### Changes

#### 1. Column Width Optimization
- Simplified column width settings to match reference implementation
- Only ID (15%) and Action (15%) columns have fixed widths
- Other columns auto-distribute remaining space for better responsiveness
- Enabled resizable prop for manual column width adjustment

#### 2. Localization Update
- Changed "Device Group" to "Group" in English localization for cleaner UI
- Chinese translation remains "设备组" for clarity

#### 3. OS Icon Display
- Added operating system icons in ID column:
  - Windows: `<WindowsFilled />`
  - Android: `<AndroidFilled />`
  - macOS/iOS: `<AppleFilled />`
  - Linux: `<QqCircleFilled />`
- Icons display with tooltip showing full OS version info
- Parse backend OS string format: `"windows / Windows 10 Pro - 10 (19045)"`

#### 4. Enhanced Online Status
- Online status badge now shows detailed tooltip
- Offline devices display duration since last online (days/hours/minutes)
- Automatic time calculation and formatting

#### 5. Tooltip Improvements
- Force OS info tooltip to display in single line
- Prevent text wrapping for better aesthetics
- Long OS names like "Windows 11 Enterprise LTSC 2024 - 11 (26100)" display cleanly

## Technical Details

### Before
```typescript
// Fixed widths for all columns
ID: 12%, Device: 18%, Group: 10%, User: 10%, 
Status: 6%, Strategy: 10%, Info: 18%, Note: 16%, Action: 15%

// Simple ID display
<Badge status={...} /> <a>{record.id}</a>
```

### After
```typescript
// Simplified width strategy
ID: 15% (fixed), Other columns: auto, Action: 15% (fixed)

// Enhanced ID display with OS icon and tooltips
<Tooltip title={onlineTooltip}>
  <Badge status={...} />
</Tooltip>
{osIcon && <Tooltip title={osTooltip}>{osIcon}</Tooltip>}
<a>{record.id}</a>
```

## Test Plan
- [ ] Verify table displays correctly on different screen sizes
- [ ] Test resizable functionality by dragging column borders
- [ ] Confirm "Group" column header displays correctly (not "Device Group")
- [ ] Verify OS icons display correctly for different operating systems
- [ ] Check offline duration calculation and display
- [ ] Verify tooltips display in single line without wrapping
- [ ] Confirm all existing features (sorting, filtering, actions) still work

## Screenshots
The device table now shows:
- OS icons next to device IDs
- Detailed online/offline status in tooltips
- Cleaner column layout with better proportions