### PR TITLE
feat: implement dark mode theme switcher

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
     configProvider: {
       theme: {
         cssVar: true,
+        dynamic: true,
         token: {
           fontFamily:
             "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import type { RequestConfig, RunTimeLayoutConfig } from '@umijs/max';
 import { history, Link } from '@umijs/max';
 import React from 'react';
 import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeSwitcher } from '@/components';
+import ThemeProvider from '@/components/ThemeProvider';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
 import { getToken } from '@/utils/auth';
 import defaultSettings from '../config/defaultSettings';
@@ -93,11 +94,7 @@ export const layout: RunTimeLayoutConfig = ({
 
   return {
     actionsRender: () => [
-      <ThemeSwitcher
-        key="ThemeSwitcher"
-        mode={initialState?.themeMode || 'light'}
-        onChange={handleThemeChange}
-      />,
+      <ThemeSwitcher key="ThemeSwitcher" />,
       <SelectLang key="SelectLang" />,
     ],
     avatarProps: {
@@ -154,3 +151,21 @@ export const layout: RunTimeLayoutConfig = ({
 export const request: RequestConfig = {
   ...errorConfig,
 };
+
+export function rootContainer(container: React.ReactNode) {
+  const storedTheme = getStoredThemeSettings();
+  const storedMode = storedTheme?.navTheme === 'dark' || storedTheme?.navTheme === 'realDark' ? 'dark' : 'light';
+  
+  // 应用初始主题类名
+  if (typeof document !== 'undefined') {
+    const root = document.documentElement;
+    if (storedMode === 'dark') {
+      root.classList.add('dark');
+    }
+  }
+
+  return React.createElement(
+    ThemeProvider,
+    { mode: storedMode, children: container }
+  );
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import { SettingDrawer } from '@ant-design/pro-components';
 import type { RequestConfig, RunTimeLayoutConfig } from '@umijs/max';
 import { history, Link } from '@umijs/max';
 import React from 'react';
-import { AvatarDropdown, AvatarName, Footer, SelectLang } from '@/components';
+import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeSwitcher } from '@/components';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
 import { getToken } from '@/utils/auth';
 import defaultSettings from '../config/defaultSettings';
@@ -16,7 +16,7 @@ const loginPath = '/user/login';
 
 const THEME_KEY = 'rustdesk_theme_settings';
 
-function getStoredThemeSettings(): Partial<LayoutSettings> | undefined {
+function getStoredThemeSettings(): any {
   try {
     const stored = localStorage.getItem(THEME_KEY);
     if (stored) {
@@ -28,7 +28,7 @@ function getStoredThemeSettings(): Partial<LayoutSettings> | undefined {
   return undefined;
 }
 
-function storeThemeSettings(settings: Partial<LayoutSettings>) {
+function storeThemeSettings(settings: any) {
   try {
     localStorage.setItem(THEME_KEY, JSON.stringify(settings));
   } catch {
@@ -41,6 +41,7 @@ export async function getInitialState(): Promise<{
   currentUser?: API.CurrentUser;
   loading?: boolean;
   fetchUserInfo?: () => Promise<API.CurrentUser | undefined>;
+  themeMode?: 'light' | 'dark';
 }> {
   const fetchUserInfo = async () => {
     try {
@@ -57,6 +58,8 @@ export async function getInitialState(): Promise<{
     ...storedTheme,
   };
 
+  const storedMode = storedTheme?.navTheme === 'dark' || storedTheme?.navTheme === 'realDark' ? 'dark' : 'light';
+
   const { location } = history;
   if (![loginPath].includes(location.pathname) && getToken()) {
     const currentUser = await fetchUserInfo();
@@ -64,11 +67,13 @@ export async function getInitialState(): Promise<{
       fetchUserInfo,
       currentUser,
       settings: initialSettings,
+      themeMode: storedMode,
     };
   }
   return {
     fetchUserInfo,
     settings: initialSettings,
+    themeMode: storedMode,
   };
 }
 
@@ -76,8 +81,25 @@ export const layout: RunTimeLayoutConfig = ({
   initialState,
   setInitialState,
 }) => {
+  const handleThemeChange = (mode: 'light' | 'dark') => {
+    const newNavTheme = mode === 'dark' ? 'dark' : 'light';
+    storeThemeSettings({ ...initialState?.settings, navTheme: newNavTheme });
+    setInitialState((pre: any) => ({
+      ...pre,
+      settings: { ...pre?.settings, navTheme: newNavTheme },
+      themeMode: mode,
+    }));
+  };
+
   return {
-    actionsRender: () => [<SelectLang key="SelectLang" />],
+    actionsRender: () => [
+      <ThemeSwitcher
+        key="ThemeSwitcher"
+        mode={initialState?.themeMode || 'light'}
+        onChange={handleThemeChange}
+      />,
+      <SelectLang key="SelectLang" />,
+    ],
     avatarProps: {
       src: undefined,
       title: <AvatarName />,
@@ -113,11 +135,12 @@ export const layout: RunTimeLayoutConfig = ({
             disableUrlParams
             enableDarkTheme
             settings={initialState?.settings}
-            onSettingChange={(settings) => {
+            onSettingChange={(settings: any) => {
               storeThemeSettings(settings);
-              setInitialState((preInitialState) => ({
+              setInitialState((preInitialState: any) => ({
                 ...preInitialState,
                 settings,
+                themeMode: settings.navTheme === 'dark' ? 'dark' : 'light',
               }));
             }}
           />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeSwitcher } from '@
 import ThemeProvider from '@/components/ThemeProvider';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
 import { getToken } from '@/utils/auth';
+import { getStoredThemeSettings, storeThemeSettings, type ThemeSettings } from '@/utils/theme';
 import defaultSettings from '../config/defaultSettings';
 import { errorConfig } from './requestErrorConfig';
 import '@ant-design/v5-patch-for-react-19';
@@ -15,34 +16,11 @@ import '@ant-design/v5-patch-for-react-19';
 const isDev = process.env.NODE_ENV === 'development' || process.env.CI;
 const loginPath = '/user/login';
 
-const THEME_KEY = 'rustdesk_theme_settings';
-
-function getStoredThemeSettings(): any {
-  try {
-    const stored = localStorage.getItem(THEME_KEY);
-    if (stored) {
-      return JSON.parse(stored);
-    }
-  } catch {
-    // ignore
-  }
-  return undefined;
-}
-
-function storeThemeSettings(settings: any) {
-  try {
-    localStorage.setItem(THEME_KEY, JSON.stringify(settings));
-  } catch {
-    // ignore
-  }
-}
-
 export async function getInitialState(): Promise<{
   settings?: Partial<LayoutSettings>;
   currentUser?: API.CurrentUser;
   loading?: boolean;
   fetchUserInfo?: () => Promise<API.CurrentUser | undefined>;
-  themeMode?: 'light' | 'dark';
 }> {
   const fetchUserInfo = async () => {
     try {
@@ -57,9 +35,7 @@ export async function getInitialState(): Promise<{
   const initialSettings = {
     ...(defaultSettings as Partial<LayoutSettings>),
     ...storedTheme,
-  };
-
-  const storedMode = storedTheme?.navTheme === 'dark' || storedTheme?.navTheme === 'realDark' ? 'dark' : 'light';
+  } as Partial<LayoutSettings>;
 
   const { location } = history;
   if (![loginPath].includes(location.pathname) && getToken()) {
@@ -68,13 +44,11 @@ export async function getInitialState(): Promise<{
       fetchUserInfo,
       currentUser,
       settings: initialSettings,
-      themeMode: storedMode,
     };
   }
   return {
     fetchUserInfo,
     settings: initialSettings,
-    themeMode: storedMode,
   };
 }
 
@@ -82,16 +56,6 @@ export const layout: RunTimeLayoutConfig = ({
   initialState,
   setInitialState,
 }) => {
-  const handleThemeChange = (mode: 'light' | 'dark') => {
-    const newNavTheme = mode === 'dark' ? 'dark' : 'light';
-    storeThemeSettings({ ...initialState?.settings, navTheme: newNavTheme });
-    setInitialState((pre: any) => ({
-      ...pre,
-      settings: { ...pre?.settings, navTheme: newNavTheme },
-      themeMode: mode,
-    }));
-  };
-
   return {
     actionsRender: () => [
       <ThemeSwitcher key="ThemeSwitcher" />,
@@ -132,12 +96,11 @@ export const layout: RunTimeLayoutConfig = ({
             disableUrlParams
             enableDarkTheme
             settings={initialState?.settings}
-            onSettingChange={(settings: any) => {
-              storeThemeSettings(settings);
+            onSettingChange={(settings) => {
+              storeThemeSettings(settings as ThemeSettings);
               setInitialState((preInitialState: any) => ({
                 ...preInitialState,
                 settings,
-                themeMode: settings.navTheme === 'dark' ? 'dark' : 'light',
               }));
             }}
           />
@@ -153,19 +116,8 @@ export const request: RequestConfig = {
 };
 
 export function rootContainer(container: React.ReactNode) {
-  const storedTheme = getStoredThemeSettings();
-  const storedMode = storedTheme?.navTheme === 'dark' || storedTheme?.navTheme === 'realDark' ? 'dark' : 'light';
-  
-  // 应用初始主题类名
-  if (typeof document !== 'undefined') {
-    const root = document.documentElement;
-    if (storedMode === 'dark') {
-      root.classList.add('dark');
-    }
-  }
-
   return React.createElement(
     ThemeProvider,
-    { mode: storedMode, children: container }
+    { mode: undefined, children: container }
   );
 }

--- a/src/components/RightContent/ThemeSwitcher.tsx
+++ b/src/components/RightContent/ThemeSwitcher.tsx
@@ -1,0 +1,56 @@
+import { MoonOutlined, SunOutlined } from '@ant-design/icons';
+import React, { useEffect, useState } from 'react';
+import { createStyles } from 'antd-style';
+
+const useStyles = createStyles(({ token, css }) => ({
+  wrapper: css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+    &:hover {
+      background-color: ${token.colorFillSecondary};
+    }
+  `,
+}));
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface ThemeSwitcherProps {
+  mode?: ThemeMode;
+  onChange?: (mode: ThemeMode) => void;
+}
+
+const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
+  mode = 'light',
+  onChange,
+}) => {
+  const { styles } = useStyles();
+  const [currentMode, setCurrentMode] = useState<ThemeMode>(mode);
+
+  useEffect(() => {
+    setCurrentMode(mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    const newMode: ThemeMode = currentMode === 'light' ? 'dark' : 'light';
+    setCurrentMode(newMode);
+    onChange?.(newMode);
+  };
+
+  return (
+    <div className={styles.wrapper} onClick={toggleTheme} title={currentMode === 'light' ? '切换到深色模式' : '切换到浅色模式'}>
+      {currentMode === 'light' ? (
+        <MoonOutlined style={{ fontSize: 16 }} />
+      ) : (
+        <SunOutlined style={{ fontSize: 16 }} />
+      )}
+    </div>
+  );
+};
+
+export { ThemeSwitcher };

--- a/src/components/RightContent/ThemeSwitcher.tsx
+++ b/src/components/RightContent/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 import { MoonOutlined, SunOutlined } from '@ant-design/icons';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { createStyles } from 'antd-style';
+import { useTheme } from '@/components/ThemeProvider';
 
 const useStyles = createStyles(({ token, css }) => ({
   wrapper: css`
@@ -18,33 +19,20 @@ const useStyles = createStyles(({ token, css }) => ({
   `,
 }));
 
-export type ThemeMode = 'light' | 'dark';
+export interface ThemeSwitcherProps {}
 
-export interface ThemeSwitcherProps {
-  mode?: ThemeMode;
-  onChange?: (mode: ThemeMode) => void;
-}
-
-const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({
-  mode = 'light',
-  onChange,
-}) => {
+const ThemeSwitcher: React.FC<ThemeSwitcherProps> = () => {
   const { styles } = useStyles();
-  const [currentMode, setCurrentMode] = useState<ThemeMode>(mode);
-
-  useEffect(() => {
-    setCurrentMode(mode);
-  }, [mode]);
+  const { mode, setMode } = useTheme();
 
   const toggleTheme = () => {
-    const newMode: ThemeMode = currentMode === 'light' ? 'dark' : 'light';
-    setCurrentMode(newMode);
-    onChange?.(newMode);
+    const newMode = mode === 'light' ? 'dark' : 'light';
+    setMode(newMode);
   };
 
   return (
-    <div className={styles.wrapper} onClick={toggleTheme} title={currentMode === 'light' ? '切换到深色模式' : '切换到浅色模式'}>
-      {currentMode === 'light' ? (
+    <div className={styles.wrapper} onClick={toggleTheme} title={mode === 'light' ? '切换到深色模式' : '切换到浅色模式'}>
+      {mode === 'light' ? (
         <MoonOutlined style={{ fontSize: 16 }} />
       ) : (
         <SunOutlined style={{ fontSize: 16 }} />

--- a/src/components/RightContent/ThemeSwitcher.tsx
+++ b/src/components/RightContent/ThemeSwitcher.tsx
@@ -1,28 +1,10 @@
 import { MoonOutlined, SunOutlined } from '@ant-design/icons';
 import React from 'react';
-import { createStyles } from 'antd-style';
 import { useTheme } from '@/components/ThemeProvider';
-
-const useStyles = createStyles(({ token, css }) => ({
-  wrapper: css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: all 0.2s;
-    &:hover {
-      background-color: ${token.colorFillSecondary};
-    }
-  `,
-}));
 
 export interface ThemeSwitcherProps {}
 
 const ThemeSwitcher: React.FC<ThemeSwitcherProps> = () => {
-  const { styles } = useStyles();
   const { mode, setMode } = useTheme();
 
   const toggleTheme = () => {
@@ -30,8 +12,33 @@ const ThemeSwitcher: React.FC<ThemeSwitcherProps> = () => {
     setMode(newMode);
   };
 
+  const wrapperStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '32px',
+    height: '32px',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+  };
+
+  const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.backgroundColor = 'var(--ant-color-fill-secondary, rgba(0, 0, 0, 0.06))';
+  };
+
+  const handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.backgroundColor = 'transparent';
+  };
+
   return (
-    <div className={styles.wrapper} onClick={toggleTheme} title={mode === 'light' ? '切换到深色模式' : '切换到浅色模式'}>
+    <div
+      style={wrapperStyle}
+      onClick={toggleTheme}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      title={mode === 'light' ? '切换到深色模式' : '切换到浅色模式'}
+    >
       {mode === 'light' ? (
         <MoonOutlined style={{ fontSize: 16 }} />
       ) : (

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -1,11 +1,12 @@
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { SelectLang as UmiSelectLang } from '@umijs/max';
 import React from 'react';
-import { ThemeSwitcher, type ThemeMode } from './ThemeSwitcher';
+import { ThemeSwitcher } from './ThemeSwitcher';
+import ThemeProvider, { type ThemeMode, useTheme } from '../ThemeProvider';
 
 export type SiderTheme = 'light' | 'dark';
 
-export { ThemeSwitcher, type ThemeMode } from './ThemeSwitcher';
+export { ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode };
 
 export const SelectLang: React.FC = () => {
   return (

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -1,7 +1,11 @@
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { SelectLang as UmiSelectLang } from '@umijs/max';
+import React from 'react';
+import { ThemeSwitcher, type ThemeMode } from './ThemeSwitcher';
 
 export type SiderTheme = 'light' | 'dark';
+
+export { ThemeSwitcher, type ThemeMode } from './ThemeSwitcher';
 
 export const SelectLang: React.FC = () => {
   return (

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -2,11 +2,10 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { SelectLang as UmiSelectLang } from '@umijs/max';
 import React from 'react';
 import { ThemeSwitcher } from './ThemeSwitcher';
-import ThemeProvider, { type ThemeMode, useTheme } from '../ThemeProvider';
 
 export type SiderTheme = 'light' | 'dark';
 
-export { ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode };
+export { ThemeSwitcher };
 
 export const SelectLang: React.FC = () => {
   return (

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -67,11 +67,20 @@ function storeThemeMode(mode: ThemeMode) {
   }
 }
 
-const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode = 'light', children }) => {
-  const [currentMode, setCurrentMode] = useState<ThemeMode>(mode);
+const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode, children }) => {
+  // 初始化时从 localStorage 读取主题设置，如果没有则使用传入的 mode 或默认 light
+  const getInitialMode = (): ThemeMode => {
+    const storedMode = getStoredThemeMode();
+    return mode || storedMode;
+  };
+  
+  const [currentMode, setCurrentMode] = useState<ThemeMode>(getInitialMode());
 
+  // 当传入的 mode 变化时更新当前模式
   useEffect(() => {
-    setCurrentMode(mode);
+    if (mode) {
+      setCurrentMode(mode);
+    }
   }, [mode]);
 
   const setMode = (newMode: ThemeMode) => {

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState, createContext, useContext } from 'react';
 import { ConfigProvider, theme } from 'antd';
 import type { ThemeConfig } from 'antd';
-
-const THEME_KEY = 'rustdesk_theme_settings';
+import { getStoredThemeMode, storeThemeMode, type ThemeMode } from '@/utils/theme';
 
 const darkTheme: ThemeConfig = {
   algorithm: [theme.darkAlgorithm],
@@ -18,8 +17,6 @@ const lightTheme: ThemeConfig = {
     colorTextBase: '#000000',
   },
 };
-
-export type ThemeMode = 'light' | 'dark';
 
 export interface ThemeProviderProps {
   mode?: ThemeMode;
@@ -41,40 +38,14 @@ export const useTheme = () => {
   return context;
 };
 
-function getStoredThemeMode(): ThemeMode {
-  try {
-    const stored = localStorage.getItem(THEME_KEY);
-    if (stored) {
-      const settings = JSON.parse(stored);
-      if (settings.navTheme === 'dark' || settings.navTheme === 'realDark') {
-        return 'dark';
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return 'light';
-}
-
-function storeThemeMode(mode: ThemeMode) {
-  try {
-    const stored = localStorage.getItem(THEME_KEY);
-    const settings = stored ? JSON.parse(stored) : {};
-    settings.navTheme = mode === 'dark' ? 'dark' : 'light';
-    localStorage.setItem(THEME_KEY, JSON.stringify(settings));
-  } catch {
-    // ignore
-  }
-}
-
 const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode, children }) => {
   // 初始化时从 localStorage 读取主题设置，如果没有则使用传入的 mode 或默认 light
   const getInitialMode = (): ThemeMode => {
     const storedMode = getStoredThemeMode();
     return mode || storedMode;
   };
-  
-  const [currentMode, setCurrentMode] = useState<ThemeMode>(getInitialMode());
+
+  const [currentMode, setCurrentMode] = useState<ThemeMode>(getInitialMode);
 
   // 当传入的 mode 变化时更新当前模式
   useEffect(() => {

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, createContext, useContext } from 'react';
+import { ConfigProvider, theme } from 'antd';
+import type { ThemeConfig } from 'antd';
+
+const darkTheme: ThemeConfig = {
+  algorithm: [theme.darkAlgorithm],
+  token: {
+    colorBgBase: '#141414',
+    colorTextBase: '#ffffff',
+  },
+};
+
+const lightTheme: ThemeConfig = {
+  token: {
+    colorBgBase: '#ffffff',
+    colorTextBase: '#000000',
+  },
+};
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface ThemeProviderProps {
+  mode?: ThemeMode;
+  children: React.ReactNode;
+}
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode = 'light', children }) => {
+  const [currentMode, setCurrentMode] = useState<ThemeMode>(mode);
+
+  useEffect(() => {
+    setCurrentMode(mode);
+  }, [mode]);
+
+  const setMode = (newMode: ThemeMode) => {
+    setCurrentMode(newMode);
+  };
+
+  useEffect(() => {
+    // 应用 CSS 变量到根元素
+    const root = document.documentElement;
+    if (currentMode === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [currentMode]);
+
+  return (
+    <ThemeContext.Provider value={{ mode: currentMode, setMode }}>
+      <ConfigProvider theme={currentMode === 'dark' ? darkTheme : lightTheme}>
+        {children}
+      </ConfigProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState, createContext, useContext } from 'react';
 import { ConfigProvider, theme } from 'antd';
 import type { ThemeConfig } from 'antd';
 
+const THEME_KEY = 'rustdesk_theme_settings';
+
 const darkTheme: ThemeConfig = {
   algorithm: [theme.darkAlgorithm],
   token: {
@@ -39,6 +41,32 @@ export const useTheme = () => {
   return context;
 };
 
+function getStoredThemeMode(): ThemeMode {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored) {
+      const settings = JSON.parse(stored);
+      if (settings.navTheme === 'dark' || settings.navTheme === 'realDark') {
+        return 'dark';
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return 'light';
+}
+
+function storeThemeMode(mode: ThemeMode) {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    const settings = stored ? JSON.parse(stored) : {};
+    settings.navTheme = mode === 'dark' ? 'dark' : 'light';
+    localStorage.setItem(THEME_KEY, JSON.stringify(settings));
+  } catch {
+    // ignore
+  }
+}
+
 const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode = 'light', children }) => {
   const [currentMode, setCurrentMode] = useState<ThemeMode>(mode);
 
@@ -48,6 +76,7 @@ const ThemeProvider: React.FC<ThemeProviderProps> = ({ mode = 'light', children 
 
   const setMode = (newMode: ThemeMode) => {
     setCurrentMode(newMode);
+    storeThemeMode(newMode);
   };
 
   useEffect(() => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,7 +6,7 @@
  * 布局组件
  */
 import Footer from './Footer';
-import { Question, SelectLang } from './RightContent';
+import { Question, SelectLang, ThemeSwitcher, type ThemeMode } from './RightContent';
 import { AvatarDropdown, AvatarName } from './RightContent/AvatarDropdown';
 
-export { AvatarDropdown, AvatarName, Footer, Question, SelectLang };
+export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeSwitcher, type ThemeMode };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,7 +6,7 @@
  * 布局组件
  */
 import Footer from './Footer';
-import { Question, SelectLang, ThemeSwitcher, type ThemeMode } from './RightContent';
+import { Question, SelectLang, ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode } from './RightContent';
 import { AvatarDropdown, AvatarName } from './RightContent/AvatarDropdown';
 
-export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeSwitcher, type ThemeMode };
+export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,7 +6,7 @@
  * 布局组件
  */
 import Footer from './Footer';
-import { Question, SelectLang, ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode } from './RightContent';
+import { Question, SelectLang, ThemeSwitcher } from './RightContent';
 import { AvatarDropdown, AvatarName } from './RightContent/AvatarDropdown';
 
-export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeSwitcher, ThemeProvider, useTheme, type ThemeMode };
+export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeSwitcher };

--- a/src/locales/en-US/settingDrawer.ts
+++ b/src/locales/en-US/settingDrawer.ts
@@ -2,6 +2,8 @@ export default {
   'app.setting.pagestyle': 'Page style setting',
   'app.setting.pagestyle.dark': 'Dark style',
   'app.setting.pagestyle.light': 'Light style',
+  'app.setting.dark.theme': 'Dark Theme',
+  'app.setting.light.theme': 'Light Theme',
   'app.setting.content-width': 'Content Width',
   'app.setting.content-width.fixed': 'Fixed',
   'app.setting.content-width.fluid': 'Fluid',

--- a/src/locales/zh-CN/settingDrawer.ts
+++ b/src/locales/zh-CN/settingDrawer.ts
@@ -2,6 +2,8 @@ export default {
   'app.setting.pagestyle': '整体风格设置',
   'app.setting.pagestyle.dark': '暗色菜单风格',
   'app.setting.pagestyle.light': '亮色菜单风格',
+  'app.setting.dark.theme': '深色主题',
+  'app.setting.light.theme': '浅色主题',
   'app.setting.content-width': '内容区域宽度',
   'app.setting.content-width.fixed': '定宽',
   'app.setting.content-width.fluid': '流式',

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,79 @@
+export const THEME_KEY = 'rustdesk_theme_settings';
+
+export type ThemeMode = 'light' | 'dark';
+
+export type NavTheme = 'light' | 'dark' | 'realDark';
+
+export interface ThemeSettings {
+  navTheme?: NavTheme;
+  layout?: 'side' | 'top' | 'mix';
+  contentWidth?: 'Fixed' | 'Fluid';
+  fixedHeader?: boolean;
+  fixSiderbar?: boolean;
+  autoHideHeader?: boolean;
+  splitMenus?: boolean;
+  colorPrimary?: string;
+  sideTheme?: 'dark' | 'light';
+  colorWeak?: boolean;
+  menu?: {
+    hide?: boolean;
+    locale?: boolean;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * 从 localStorage 读取主题设置
+ */
+export function getStoredThemeSettings(): ThemeSettings | undefined {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+/**
+ * 保存主题设置到 localStorage
+ */
+export function storeThemeSettings(settings: ThemeSettings): void {
+  try {
+    localStorage.setItem(THEME_KEY, JSON.stringify(settings));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 从 localStorage 读取主题模式
+ */
+export function getStoredThemeMode(): ThemeMode {
+  const settings = getStoredThemeSettings();
+  if (settings?.navTheme === 'dark' || settings?.navTheme === 'realDark') {
+    return 'dark';
+  }
+  return 'light';
+}
+
+/**
+ * 保存主题模式到 localStorage
+ */
+export function storeThemeMode(mode: ThemeMode): void {
+  const stored = getStoredThemeSettings();
+  const settings: ThemeSettings = {
+    ...(stored || {}),
+    navTheme: mode,
+  };
+  storeThemeSettings(settings);
+}
+
+/**
+ * 获取当前主题模式（从 localStorage 或默认值）
+ */
+export function getCurrentThemeMode(): ThemeMode {
+  return getStoredThemeMode();
+}


### PR DESCRIPTION
## Summary
This PR implements a dark mode theme switcher for the application.

## Changes
- Added ThemeProvider component with Context API for global theme management
- Added ThemeSwitcher component with moon/sun icons for theme toggle
- Integrated theme toggle button into header actions (next to language selector)
- Added theme persistence to localStorage for user preference
- Updated i18n translations for theme options (Chinese and English)
- Enabled dynamic theme support in config.ts
- Supports switching between light and dark themes using Ant Design's darkAlgorithm

## Technical Details
- Uses antd's ConfigProvider with darkAlgorithm for full application dark mode
- Theme state is managed via React Context (useTheme hook)
- Theme preference is saved to localStorage and restored on page reload

## Testing
- Click the moon/sun icon in the header to toggle between light and dark themes
- Theme preference is saved and restored on page reload
- Full application theme changes (not just sidebar)