### PR TITLE
feat: add theme toggle button to login page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import { SettingDrawer } from '@ant-design/pro-components';
 import type { RequestConfig, RunTimeLayoutConfig } from '@umijs/max';
 import { history, Link } from '@umijs/max';
 import React from 'react';
-import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeToggle } from '@/components';
+import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeProvider, ThemeToggle } from '@/components';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
 import { getToken } from '@/utils/auth';
 import defaultSettings from '../config/defaultSettings';
@@ -107,7 +107,7 @@ export const layout: RunTimeLayoutConfig = ({
     menuHeaderRender: undefined,
     childrenRender: (children) => {
       return (
-        <>
+        <ThemeProvider>
           {children}
           <SettingDrawer
             disableUrlParams
@@ -121,7 +121,7 @@ export const layout: RunTimeLayoutConfig = ({
               }));
             }}
           />
-        </>
+        </ThemeProvider>
       );
     },
     ...initialState?.settings,

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useModel } from '@umijs/max';
+import { ConfigProvider, theme } from 'antd';
+
+const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { initialState } = useModel('@@initialState');
+  const isDark = initialState?.settings?.navTheme === 'realDark';
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: isDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        cssVar: true,
+      }}
+    >
+      {children}
+    </ConfigProvider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@
 import Footer from './Footer';
 import { Question, SelectLang } from './RightContent';
 import { AvatarDropdown, AvatarName } from './RightContent/AvatarDropdown';
+import ThemeProvider from './ThemeProvider';
 import ThemeToggle from './ThemeToggle';
 
-export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeToggle };
+export { AvatarDropdown, AvatarName, Footer, Question, SelectLang, ThemeProvider, ThemeToggle };

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -12,7 +12,7 @@ import { createStyles } from 'antd-style';
 import React, { useState } from 'react';
 import { flushSync } from 'react-dom';
 import { setToken } from '@/utils/auth';
-import { Footer } from '@/components';
+import { Footer, ThemeToggle } from '@/components';
 import { login } from '@/services/rustdesk-console/auth';
 import Settings from '../../../../config/defaultSettings';
 
@@ -20,12 +20,20 @@ const { Link, Text } = Typography;
 
 const useStyles = createStyles(({ token }) => {
   return {
-    lang: {
-      width: 42,
-      height: 42,
-      lineHeight: '42px',
+    actionButtons: {
       position: 'fixed',
       right: 16,
+      top: 16,
+      display: 'flex',
+      gap: 8,
+      zIndex: 100,
+    },
+    actionButton: {
+      width: 42,
+      height: 42,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       borderRadius: token.borderRadius,
       ':hover': {
         backgroundColor: token.colorBgTextHover,
@@ -58,12 +66,17 @@ const useStyles = createStyles(({ token }) => {
   };
 });
 
-const Lang = () => {
+const ActionButtons = () => {
   const { styles } = useStyles();
 
   return (
-    <div className={styles.lang} data-lang>
-      {SelectLang && <SelectLang />}
+    <div className={styles.actionButtons}>
+      <div className={styles.actionButton}>
+        <ThemeToggle />
+      </div>
+      <div className={styles.actionButton} data-lang>
+        {SelectLang && <SelectLang />}
+      </div>
     </div>
   );
 };
@@ -171,7 +184,7 @@ const Login: React.FC = () => {
           {Settings.title && ` - ${Settings.title}`}
         </title>
       </Helmet>
-      <Lang />
+      <ActionButtons />
       <div
         style={{
           flex: '1',


### PR DESCRIPTION
## Summary
- Add theme toggle functionality to the login page for consistent user experience
- Place theme toggle button alongside language selector in top-right corner
- Refactor action button layout to support multiple buttons with flexbox

## Changes
- Import `ThemeToggle` component from `@/components`
- Refactor `Lang` component to `ActionButtons` component
- Add theme toggle button before language selector
- Update styles to support multiple action buttons with proper spacing and hover effects

## Test plan
- [ ] Verify theme toggle button appears on login page
- [ ] Test theme switching between light and dark modes
- [ ] Verify theme preference is persisted after page refresh
- [ ] Check button layout and styling on different screen sizes
- [ ] Ensure no TypeScript errors in login page