### PR TITLE
fix: improve SMTP error handling by using global error handler

### DIFF
--- a/src/pages/settings/smtp/index.tsx
+++ b/src/pages/settings/smtp/index.tsx
@@ -63,12 +63,8 @@ const SMTPSettings: React.FC = () => {
         // 404 表示配置不存在，这是正常情况，不需要显示错误提示
         setConfigExists(false);
       } else {
-        messageApi.error(
-          intl.formatMessage({
-            id: 'pages.smtp.loadFailed',
-            defaultMessage: 'Failed to load SMTP configuration',
-          }),
-        );
+        // 其他错误重新抛出，让全局错误处理器处理
+        throw error;
       }
     } finally {
       setLoading(false);

--- a/src/services/rustdesk-console/smtp.ts
+++ b/src/services/rustdesk-console/smtp.ts
@@ -6,7 +6,6 @@ import { request } from '@umijs/max';
 export async function getSMTPConfig() {
   return request<API.SMTPConfig>('/api/settings/smtp', {
     method: 'GET',
-    skipErrorHandler: true,
   });
 }
 


### PR DESCRIPTION
## Summary
This PR fixes the error handling issue in SMTP configuration by removing the `skipErrorHandler` flag and implementing proper error handling flow.

## Problem
The previous implementation used `skipErrorHandler: true` in the `getSMTPConfig` API call, which bypassed the global error handler for **all** errors, including:
- 401 Unauthorized errors (should redirect to login)
- 403 Forbidden errors (should show access denied)
- Network errors (should show no response message)
- Server errors (should show error status)

This broke the unified error handling flow across the application.

## Solution
1. **Remove `skipErrorHandler`** from the API call
2. **Only catch 404 errors** in the component - this is a normal case when SMTP config doesn't exist yet
3. **Re-throw other errors** to let the global error handler process them

## Benefits
- ✅ Maintains unified error handling flow
- ✅ 401 errors will properly redirect to login page
- ✅ 403 errors will show access denied message
- ✅ Network and server errors are handled consistently
- ✅ 404 errors (config not found) are still handled silently as before

## Testing
- [ ] Test accessing SMTP settings when config doesn't exist (should not show error)
- [ ] Test with invalid authentication (should redirect to login)
- [ ] Test with server error (should show error message)
- [ ] Test saving SMTP configuration
- [ ] Test connection test functionality