### PR TITLE
fix(auth): resolve multi-tab login state sync and auth issues

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,11 +2,11 @@ import { LinkOutlined } from '@ant-design/icons';
 import type { Settings as LayoutSettings } from '@ant-design/pro-components';
 import { SettingDrawer } from '@ant-design/pro-components';
 import type { RequestConfig, RunTimeLayoutConfig } from '@umijs/max';
-import { history, Link } from '@umijs/max';
-import React from 'react';
+import { history, Link, useModel } from '@umijs/max';
+import React, { useEffect } from 'react';
 import { AvatarDropdown, AvatarName, Footer, SelectLang, ThemeToggle } from '@/components';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
-import { getToken } from '@/utils/auth';
+import { getToken, TOKEN_KEY } from '@/utils/auth';
 import defaultSettings from '../config/defaultSettings';
 import { errorConfig } from './requestErrorConfig';
 import '@ant-design/v5-patch-for-react-19';
@@ -46,8 +46,11 @@ export async function getInitialState(): Promise<{
     try {
       const msg = await queryCurrentUser();
       return msg;
-    } catch (_error) {
-      history.push(loginPath);
+    } catch (error: any) {
+      const status = error?.response?.status;
+      if (status === 401) {
+        history.push(loginPath);
+      }
     }
     return undefined;
   };
@@ -71,6 +74,38 @@ export async function getInitialState(): Promise<{
     settings: initialSettings,
   };
 }
+
+const AuthSync: React.FC = () => {
+  const { initialState, setInitialState, refresh } = useModel('@@initialState');
+
+  useEffect(() => {
+    const handleSessionExpired = () => {
+      setInitialState((s) => ({ ...s, currentUser: undefined }));
+    };
+
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === TOKEN_KEY) {
+        if (!e.newValue) {
+          setInitialState((s) => ({ ...s, currentUser: undefined }));
+          if (history.location.pathname !== loginPath) {
+            history.push(loginPath);
+          }
+        } else if (e.newValue && !initialState?.currentUser) {
+          refresh();
+        }
+      }
+    };
+
+    window.addEventListener('auth:session-expired', handleSessionExpired);
+    window.addEventListener('storage', handleStorageChange);
+    return () => {
+      window.removeEventListener('auth:session-expired', handleSessionExpired);
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [initialState?.currentUser, setInitialState, refresh]);
+
+  return null;
+};
 
 export const layout: RunTimeLayoutConfig = ({
   initialState,
@@ -108,6 +143,7 @@ export const layout: RunTimeLayoutConfig = ({
     childrenRender: (children) => {
       return (
         <>
+          <AuthSync />
           {children}
           <SettingDrawer
             disableUrlParams

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -1,13 +1,14 @@
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
-import { LoginForm, ProFormCheckbox, ProFormText } from '@ant-design/pro-components';
+import { LoginForm, ProFormText } from '@ant-design/pro-components';
 import {
   FormattedMessage,
   Helmet,
   SelectLang,
   useIntl,
   useModel,
+  history,
 } from '@umijs/max';
-import { Alert, App, Checkbox, Space, Typography } from 'antd';
+import { Alert, App, Checkbox } from 'antd';
 import { createStyles } from 'antd-style';
 import React, { useState } from 'react';
 import { flushSync } from 'react-dom';
@@ -15,8 +16,6 @@ import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
 import { login } from '@/services/rustdesk-console/auth';
 import Settings from '../../../../config/defaultSettings';
-
-const { Link, Text } = Typography;
 
 const useStyles = createStyles(({ token }) => {
   return {
@@ -106,25 +105,11 @@ const Login: React.FC = () => {
   const handleSubmit = async (values: API.LoginParams & { rememberMe?: boolean }) => {
     try {
       const msg = await login(values);
-      console.log('=== LOGIN DEBUG ===');
-      console.log('Full login response (msg):', JSON.stringify(msg));
-      console.log('msg type:', typeof msg);
-      console.log('msg keys:', msg ? Object.keys(msg) : 'null');
-      console.log('msg.access_token:', msg?.access_token);
-      console.log('msg.data:', msg?.data);
-      console.log('msg.data?.access_token:', msg?.data?.access_token);
-      
-      // 尝试不同的token提取方式
       const token = msg?.access_token || msg?.data?.access_token;
-      console.log('Extracted token:', token ? 'YES (length: ' + token.length + ')' : 'NO');
-      
+
       if (token) {
-        console.log('Setting token...');
         setToken(token, values.rememberMe);
-        // 验证token是否保存成功
-        const storedToken = sessionStorage.getItem('rustdesk_access_token') || localStorage.getItem('rustdesk_access_token');
-        console.log('Token stored?', storedToken ? 'YES' : 'NO');
-        
+
         const defaultLoginSuccessMessage = intl.formatMessage({
           id: 'pages.login.success',
           defaultMessage: 'Login successful!',
@@ -132,7 +117,7 @@ const Login: React.FC = () => {
         message.success(defaultLoginSuccessMessage);
         await fetchUserInfo();
         const urlParams = new URL(window.location.href).searchParams;
-        window.location.href = urlParams.get('redirect') || '/';
+        history.push(urlParams.get('redirect') || '/');
         return;
       }
       setLoginError(

--- a/src/requestErrorConfig.ts
+++ b/src/requestErrorConfig.ts
@@ -65,6 +65,7 @@ export const errorConfig: RequestConfig = {
         const status = error.response.status;
         if (status === 401) {
           removeToken();
+          window.dispatchEvent(new CustomEvent('auth:session-expired'));
           history.push(loginPath);
           message.error('Login expired, please login again');
           return;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,18 +1,24 @@
-const TOKEN_KEY = 'rustdesk_access_token';
+export const TOKEN_KEY = 'rustdesk_access_token';
+const REMEMBER_ME_KEY = 'rustdesk_remember_me';
 
 export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+  return localStorage.getItem(TOKEN_KEY);
 }
 
 export function setToken(token: string, rememberMe: boolean = false) {
+  localStorage.setItem(TOKEN_KEY, token);
   if (rememberMe) {
-    localStorage.setItem(TOKEN_KEY, token);
+    localStorage.setItem(REMEMBER_ME_KEY, 'true');
   } else {
-    sessionStorage.setItem(TOKEN_KEY, token);
+    localStorage.removeItem(REMEMBER_ME_KEY);
   }
 }
 
 export function removeToken() {
   localStorage.removeItem(TOKEN_KEY);
-  sessionStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(REMEMBER_ME_KEY);
+}
+
+export function isRememberMe(): boolean {
+  return localStorage.getItem(REMEMBER_ME_KEY) === 'true';
 }


### PR DESCRIPTION
## Summary

- **Fix cross-tab login state sync**: Store token in `localStorage` instead of `sessionStorage` to enable authentication state sharing across browser tabs
- **Add AuthSync component**: Listen for `storage` events to sync login state across tabs in real-time
- **Fix fetchUserInfo error handling**: Only redirect to login page on 401 errors, not on network failures
- **Fix 401 state cleanup**: Dispatch custom event on 401 to properly clear `initialState.currentUser`
- **Remove debug code**: Clean up `console.log` statements from login page
- **Fix hard redirect**: Replace `window.location.href` with `history.push` for smoother navigation after login

## Root Cause Analysis

The main issue was that tokens were stored in `sessionStorage` when "Remember me" was not checked. Since `sessionStorage` is tab-isolated, opening a new tab would not have access to the token, causing unexpected redirects to the login page.

## Solution

1. Always store tokens in `localStorage` for cross-tab accessibility
2. "Remember me" now only controls a flag, not the storage location
3. Added `AuthSync` component to listen for:
   - `storage` events: Sync login state when token changes in another tab
   - `auth:session-expired` event: Clear state when 401 is received
4. Improved error handling to distinguish between auth errors (401) and network errors

## Test Plan

- [ ] Login in one tab, open another tab to a protected page - should not redirect to login
- [ ] Logout in one tab - other tabs should redirect to login
- [ ] Trigger 401 response - should clear state and redirect to login
- [ ] Network error during `fetchUserInfo` - should NOT redirect to login
- [ ] Login with "Remember me" checked - should work as before
- [ ] Login without "Remember me" - should now work across tabs