### PR TITLE
fix: align table styles with Ant Design 5.x specification

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Radio, Select, Space, Tag, Table, Tooltip, Typography } from 'antd';
+import { Alert, App, Button, ColorPicker, Divider, Form, Input, Modal, Popconfirm, Radio, Select, Space, Tag, Table, Tooltip, Typography } from 'antd';
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, SelectOutlined, WindowsFilled, AndroidFilled, AppleFilled, QqCircleFilled } from '@ant-design/icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -56,7 +56,6 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
   const intl = useIntl();
   const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   
   const [addPeerModalVisible, setAddPeerModalVisible] = useState(false);
   const [editPeerModalVisible, setEditPeerModalVisible] = useState(false);
@@ -444,7 +443,7 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
       width: 160,
       fixed: "right",
       render: (_: unknown, record: API.PeerItem) => (
-        <Space size="small" split={<span style={{ color: '#ccc' }}>|</span>}>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -747,10 +746,6 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: false,

--- a/src/pages/address-book/shared/index.tsx
+++ b/src/pages/address-book/shared/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, history, useIntl } from '@umijs/max';
-import { App, Button, Form, Input, Modal, Popconfirm } from 'antd';
+import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import {
   addSharedAddressBook,
@@ -112,7 +112,7 @@ const SharedAddressBook: React.FC = () => {
       valueType: 'option',
       width: 180,
       render: (_, record) => (
-        <>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -139,7 +139,7 @@ const SharedAddressBook: React.FC = () => {
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
             </Button>
           </Popconfirm>
-        </>
+        </Space>
       ),
     },
   ];
@@ -154,7 +154,7 @@ const SharedAddressBook: React.FC = () => {
         rowKey="guid"
         request={async (params) => {
           const result = await getSharedAddressBooks({
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
             current: params.current || 1,
           });
           return {
@@ -167,6 +167,11 @@ const SharedAddressBook: React.FC = () => {
         rowSelection={{
           selectedRowKeys,
           onChange: setSelectedRowKeys,
+        }}
+        pagination={{
+          defaultPageSize: 20,
+          showSizeChanger: true,
+          showQuickJumper: true,
         }}
         toolBarRender={() => [
           <Button key="create" type="primary" onClick={() => setCreateModalVisible(true)}>
@@ -189,6 +194,15 @@ const SharedAddressBook: React.FC = () => {
             </Popconfirm>
           ),
         ]}
+        options={{
+          density: true,
+          setting: {
+            listsHeight: 400,
+          },
+          fullScreen: false,
+          reload: true,
+        }}
+        scroll={{ x: 800 }}
       />
 
       <Modal

--- a/src/pages/audits/alarm/index.tsx
+++ b/src/pages/audits/alarm/index.tsx
@@ -62,7 +62,7 @@ const AlarmAudit: React.FC = () => {
         request={async (params) => {
           const result = await getAlarmAudits({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -73,7 +73,7 @@ const AlarmAudit: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}

--- a/src/pages/audits/conn/index.tsx
+++ b/src/pages/audits/conn/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Button, message, Tag } from 'antd';
+import { App, Button, Tag } from 'antd';
 import React, { useRef, useState } from 'react';
 import { getConnectionAudits } from '@/services/rustdesk-console/audit';
 import { DownloadOutlined } from '@ant-design/icons';
@@ -9,12 +9,13 @@ import dayjs from 'dayjs';
 
 const ConnectionAudit: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [dataSource, setDataSource] = useState<API.ConnectionAuditItem[]>([]);
 
   const handleExportCSV = () => {
     if (dataSource.length === 0) {
-      message.warning(
+      msgApi.warning(
         intl.formatMessage({
           id: 'pages.audits.noDataToExport',
           defaultMessage: 'No data to export',
@@ -57,7 +58,7 @@ const ConnectionAudit: React.FC = () => {
     link.click();
     URL.revokeObjectURL(link.href);
 
-    message.success(
+    msgApi.success(
       intl.formatMessage({
         id: 'pages.audits.exportSuccess',
         defaultMessage: 'Export successful',

--- a/src/pages/audits/console/index.tsx
+++ b/src/pages/audits/console/index.tsx
@@ -43,7 +43,7 @@ const ConsoleAudit: React.FC = () => {
         request={async (params) => {
           const result = await getConsoleAudits({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -54,7 +54,7 @@ const ConsoleAudit: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}
@@ -66,6 +66,7 @@ const ConsoleAudit: React.FC = () => {
           fullScreen: false,
           reload: true,
         }}
+        scroll={{ x: 800 }}
       />
     </PageContainer>
   );

--- a/src/pages/audits/file/index.tsx
+++ b/src/pages/audits/file/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Button, message, Tag } from 'antd';
+import { App, Button, Tag } from 'antd';
 import React, { useRef, useState } from 'react';
 import { getFileAudits } from '@/services/rustdesk-console/audit';
 import { DownloadOutlined } from '@ant-design/icons';
@@ -9,12 +9,13 @@ import dayjs from 'dayjs';
 
 const FileAudit: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [dataSource, setDataSource] = useState<API.FileAuditItem[]>([]);
 
   const handleExportCSV = () => {
     if (dataSource.length === 0) {
-      message.warning(
+      msgApi.warning(
         intl.formatMessage({
           id: 'pages.audits.noDataToExport',
           defaultMessage: 'No data to export',
@@ -58,7 +59,7 @@ const FileAudit: React.FC = () => {
     link.click();
     URL.revokeObjectURL(link.href);
 
-    message.success(
+    msgApi.success(
       intl.formatMessage({
         id: 'pages.audits.exportSuccess',
         defaultMessage: 'Export successful',

--- a/src/pages/custom-client/index.tsx
+++ b/src/pages/custom-client/index.tsx
@@ -6,13 +6,13 @@ import {
   PlusOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
 } from 'antd';
@@ -27,6 +27,7 @@ import {
 
 const CustomClientList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -36,12 +37,12 @@ const CustomClientList: React.FC = () => {
   const handleCreate = async (values: API.CreateCustomClientParams) => {
     try {
       await createCustomClient(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.createSuccess', defaultMessage: 'Custom client created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.createSuccess', defaultMessage: 'Custom client created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.createFailed', defaultMessage: 'Failed to create custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.createFailed', defaultMessage: 'Failed to create custom client' }));
     }
   };
 
@@ -49,23 +50,23 @@ const CustomClientList: React.FC = () => {
     if (!currentClient) return;
     try {
       await updateCustomClient(currentClient.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.updateSuccess', defaultMessage: 'Custom client updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.updateSuccess', defaultMessage: 'Custom client updated' }));
       setEditModalVisible(false);
       setCurrentClient(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.updateFailed', defaultMessage: 'Failed to update custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.updateFailed', defaultMessage: 'Failed to update custom client' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteCustomClient(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.deleteSuccess', defaultMessage: 'Custom client deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.deleteSuccess', defaultMessage: 'Custom client deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.deleteFailed', defaultMessage: 'Failed to delete custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.deleteFailed', defaultMessage: 'Failed to delete custom client' }));
     }
   };
 
@@ -81,7 +82,7 @@ const CustomClientList: React.FC = () => {
       link.remove();
       window.URL.revokeObjectURL(url);
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.downloadFailed', defaultMessage: 'Failed to download client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.downloadFailed', defaultMessage: 'Failed to download client' }));
     }
   };
 
@@ -130,8 +131,8 @@ const CustomClientList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.customClients.deleteConfirm', defaultMessage: 'Delete this custom client?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -143,7 +144,7 @@ const CustomClientList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.CustomClientItem>
         headerTitle={<FormattedMessage id="pages.customClients.list" defaultMessage="Custom Client List" />}
         actionRef={actionRef}
@@ -194,13 +195,8 @@ const CustomClientList: React.FC = () => {
           <Input placeholder="Enter client name" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default CustomClientList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/device-groups/list/index.tsx
+++ b/src/pages/device-groups/list/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, history, useIntl } from '@umijs/max';
-import { App, Button, Form, Input, Modal, Popconfirm } from 'antd';
+import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import {
   createDeviceGroup,
@@ -110,7 +110,7 @@ const DeviceGroupList: React.FC = () => {
       valueType: 'option',
       width: 180,
       render: (_, record) => (
-        <>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -137,7 +137,7 @@ const DeviceGroupList: React.FC = () => {
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
             </Button>
           </Popconfirm>
-        </>
+        </Space>
       ),
     },
   ];
@@ -153,7 +153,7 @@ const DeviceGroupList: React.FC = () => {
         request={async (params) => {
           const result = await getDeviceGroupList({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -164,7 +164,7 @@ const DeviceGroupList: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}
@@ -176,6 +176,15 @@ const DeviceGroupList: React.FC = () => {
             />
           </Button>,
         ]}
+        options={{
+          density: true,
+          setting: {
+            listsHeight: 400,
+          },
+          fullScreen: false,
+          reload: true,
+        }}
+        scroll={{ x: 800 }}
       />
 
       <Modal

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -14,7 +14,7 @@ import { removeDeviceFromGroup } from '@/services/rustdesk-console/deviceGroup';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { App, Button, Popconfirm, Space } from 'antd';
+import { App, Button, Divider, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Settings from '../../../../config/defaultSettings';
@@ -30,8 +30,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
   const intl = useIntl();
   const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const [totalDevices, setTotalDevices] = useState<number>(0);
 
   const handleEnable = async (guid: string) => {
     try {
@@ -152,7 +150,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
       
       // Normal device list (not in device group context)
       return (
-        <Space size="small" split={<span style={{ color: '#ccc' }}>|</span>}>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button key="edit" type="link" size="small" icon={<EditOutlined />}>
             <FormattedMessage id="pages.common.edit" defaultMessage="Edit" />
           </Button>
@@ -215,13 +213,10 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
       >
       <ProTable<API.DeviceItem>
         headerTitle={
-          <span>
-            <FormattedMessage
-              id="pages.devices.list"
-              defaultMessage="Device List"
-            />{' '}
-            ({totalDevices}/-)
-          </span>
+          <FormattedMessage
+            id="pages.devices.list"
+            defaultMessage="Device List"
+          />
         }
         actionRef={actionRef}
         rowKey="guid"
@@ -237,7 +232,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
             device_group_guid: deviceGroupGuid,
             os: params.os,
           });
-          setTotalDevices(result.total || 0);
           return {
             data: result.data || [],
             total: result.total || 0,
@@ -245,10 +239,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: true,

--- a/src/pages/groups/user/index.tsx
+++ b/src/pages/groups/user/index.tsx
@@ -5,13 +5,13 @@ import {
   TeamOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
 } from 'antd';
@@ -25,6 +25,7 @@ import {
 
 const UserGroupList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -34,12 +35,12 @@ const UserGroupList: React.FC = () => {
   const handleCreate = async (values: API.CreateUserGroupParams) => {
     try {
       await createUserGroup(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.createSuccess', defaultMessage: 'User group created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.createSuccess', defaultMessage: 'User group created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.createFailed', defaultMessage: 'Failed to create user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.createFailed', defaultMessage: 'Failed to create user group' }));
     }
   };
 
@@ -47,23 +48,23 @@ const UserGroupList: React.FC = () => {
     if (!currentGroup) return;
     try {
       await updateUserGroup(currentGroup.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.updateSuccess', defaultMessage: 'User group updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.updateSuccess', defaultMessage: 'User group updated' }));
       setEditModalVisible(false);
       setCurrentGroup(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.updateFailed', defaultMessage: 'Failed to update user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.updateFailed', defaultMessage: 'Failed to update user group' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteUserGroup(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.deleteSuccess', defaultMessage: 'User group deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.deleteSuccess', defaultMessage: 'User group deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.deleteFailed', defaultMessage: 'Failed to delete user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.deleteFailed', defaultMessage: 'Failed to delete user group' }));
     }
   };
 
@@ -115,8 +116,8 @@ const UserGroupList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.userGroups.deleteConfirm', defaultMessage: 'Delete this user group?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -128,7 +129,7 @@ const UserGroupList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.UserGroupItem>
         headerTitle={<FormattedMessage id="pages.userGroups.list" defaultMessage="User Group List" />}
         actionRef={actionRef}
@@ -185,13 +186,8 @@ const UserGroupList: React.FC = () => {
           <Input.TextArea rows={3} placeholder="Enter description" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default UserGroupList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/roles/index.tsx
+++ b/src/pages/roles/index.tsx
@@ -6,14 +6,14 @@ import {
   SafetyCertificateOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Checkbox,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
   Tag,
@@ -31,6 +31,7 @@ import {
 
 const RoleList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -50,14 +51,14 @@ const RoleList: React.FC = () => {
   const handleCreate = async (values: API.CreateRoleParams) => {
     try {
       await createRole(values);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.createSuccess', defaultMessage: 'Role created successfully' }),
       );
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.createFailed', defaultMessage: 'Failed to create role' }),
       );
     }
@@ -67,7 +68,7 @@ const RoleList: React.FC = () => {
     if (!currentRole) return;
     try {
       await updateRole(currentRole.guid, values);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.updateSuccess', defaultMessage: 'Role updated successfully' }),
       );
       setEditModalVisible(false);
@@ -75,7 +76,7 @@ const RoleList: React.FC = () => {
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.updateFailed', defaultMessage: 'Failed to update role' }),
       );
     }
@@ -84,12 +85,12 @@ const RoleList: React.FC = () => {
   const handleDelete = async (guid: string) => {
     try {
       await deleteRole(guid);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.deleteSuccess', defaultMessage: 'Role deleted successfully' }),
       );
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.deleteFailed', defaultMessage: 'Failed to delete role' }),
       );
     }
@@ -118,7 +119,7 @@ const RoleList: React.FC = () => {
       width: 200,
       render: (_, record) => (
         <Space>
-          <SafetyCertificateOutlined style={{ color: '#1890ff' }} />
+          <SafetyCertificateOutlined style={{ color: '#1677ff' }} />
           <span>{record.name}</span>
         </Space>
       ),
@@ -203,7 +204,7 @@ const RoleList: React.FC = () => {
   };
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.RoleItem>
         headerTitle={
           <FormattedMessage id="pages.roles.list" defaultMessage="Role List" />
@@ -329,13 +330,8 @@ const RoleList: React.FC = () => {
           </Checkbox.Group>
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default RoleList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,12 +1,12 @@
 import { SaveOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Card,
   Form,
   Input,
-  message as messageApi,
   Select,
   Space,
   Switch,
@@ -17,6 +17,7 @@ import { getSettings, updateSetting } from '@/services/rustdesk-console/settings
 
 const Settings: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState('general');
@@ -38,7 +39,7 @@ const Settings: React.FC = () => {
       }
     } catch (error) {
       console.error('Failed to fetch settings:', error);
-      messageApi.error(intl.formatMessage({ id: 'pages.settings.fetchFailed', defaultMessage: 'Failed to load settings' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.settings.fetchFailed', defaultMessage: 'Failed to load settings' }));
     } finally {
       setLoading(false);
     }
@@ -52,9 +53,9 @@ const Settings: React.FC = () => {
           updateSetting(key, value as string | number | boolean)
         )
       );
-      messageApi.success(intl.formatMessage({ id: 'pages.settings.saveSuccess', defaultMessage: 'Settings saved successfully' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.settings.saveSuccess', defaultMessage: 'Settings saved successfully' }));
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.settings.saveFailed', defaultMessage: 'Failed to save settings' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.settings.saveFailed', defaultMessage: 'Failed to save settings' }));
     }
   };
 
@@ -126,8 +127,3 @@ const Settings: React.FC = () => {
 };
 
 export default Settings;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/strategy/index.tsx
+++ b/src/pages/strategy/index.tsx
@@ -5,13 +5,13 @@ import {
   SolutionOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
   Switch,
@@ -26,6 +26,7 @@ import {
 
 const StrategyList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -35,12 +36,12 @@ const StrategyList: React.FC = () => {
   const handleCreate = async (values: API.CreateStrategyParams) => {
     try {
       await createStrategy(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.createSuccess', defaultMessage: 'Strategy created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.createSuccess', defaultMessage: 'Strategy created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.createFailed', defaultMessage: 'Failed to create strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.createFailed', defaultMessage: 'Failed to create strategy' }));
     }
   };
 
@@ -48,23 +49,23 @@ const StrategyList: React.FC = () => {
     if (!currentStrategy) return;
     try {
       await updateStrategy(currentStrategy.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.updateSuccess', defaultMessage: 'Strategy updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.updateSuccess', defaultMessage: 'Strategy updated' }));
       setEditModalVisible(false);
       setCurrentStrategy(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.updateFailed', defaultMessage: 'Failed to update strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.updateFailed', defaultMessage: 'Failed to update strategy' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteStrategy(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.deleteSuccess', defaultMessage: 'Strategy deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.deleteSuccess', defaultMessage: 'Strategy deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.deleteFailed', defaultMessage: 'Failed to delete strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.deleteFailed', defaultMessage: 'Failed to delete strategy' }));
     }
   };
 
@@ -119,8 +120,8 @@ const StrategyList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.strategies.deleteConfirm', defaultMessage: 'Delete this strategy?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -132,7 +133,7 @@ const StrategyList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.StrategyItem>
         headerTitle={<FormattedMessage id="pages.strategies.list" defaultMessage="Strategy List" />}
         actionRef={actionRef}
@@ -189,13 +190,8 @@ const StrategyList: React.FC = () => {
           <Input.TextArea rows={3} placeholder="Enter description" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default StrategyList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/users/list/index.tsx
+++ b/src/pages/users/list/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
-import { useIntl, useModel } from '@umijs/max';
+import { FormattedMessage, useIntl, useModel } from '@umijs/max';
 import {
   App,
   Button,
@@ -43,7 +43,6 @@ const UserList: React.FC = () => {
   const [inviteModalVisible, setInviteModalVisible] = useState(false);
   const [createForm] = Form.useForm();
   const [inviteForm] = Form.useForm();
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [searchParams, setSearchParams] = useState<{
     search?: string;
     status?: string;
@@ -303,10 +302,7 @@ const UserList: React.FC = () => {
     <PageContainer>
       <ProTable<API.UserItem>
         headerTitle={
-          <span>
-            <FormattedMessage id="pages.users.list" defaultMessage="User List" /> {' '}
-            {searchParams.search ? '*' : '0'}/-
-          </span>
+          <FormattedMessage id="pages.users.list" defaultMessage="User List" />
         }
         actionRef={actionRef}
         rowKey="guid"
@@ -324,10 +320,6 @@ const UserList: React.FC = () => {
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: false,
@@ -432,8 +424,3 @@ const UserList: React.FC = () => {
 };
 
 export default UserList;
-
-function FormattedMessage(props: { id: string; defaultMessage: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}


### PR DESCRIPTION
## Summary

Align all list/table pages with Ant Design 5.x design specification and best practices.

## Changes

### 🔴 Critical Fixes
1. **Unify message API**: Replace static `message` imports with `App.useApp()` in strategy, roles, user groups, custom client, file audit, and connection audit pages
2. **Unify PageContainer**: Add missing `PageContainer` wrapper to strategy, roles, user groups, and custom client pages
3. **Unify action column separator**: Replace `Fragment` with `Space` component in device-groups and shared address book; replace hardcoded `|` with `Divider type=vertical` in devices and personal address book
4. **Remove duplicate FormattedMessage definitions**: Import from `@umijs/max` instead of local re-implementation in users, strategy, roles, user groups, and custom client pages

### 🟡 Medium Fixes
5. **Unify pagination config**: Standardize `defaultPageSize` to 20 across all list pages; add missing `showSizeChanger` and `showQuickJumper` to shared address book
6. **Unify options config**: Add consistent density/setting/reload options to device-groups and shared address book pages
7. **Unify scroll config**: Add missing `scroll={{ x }}` to device-groups, shared address book, and console audit pages
8. **Remove unused rowSelection**: Remove `rowSelection` from pages without batch operations (devices, personal address book, users)

### 🟢 Minor Fixes
9. **Unify Popconfirm okText/cancelText**: Use `intl.formatMessage` instead of hardcoded Yes/No strings
10. **Update color value**: Change `#1890ff` (antd v4) to `#1677ff` (antd v5) in roles page
11. **Clean up headerTitle**: Remove ambiguous count display format in devices and users pages

## Test Plan
- [x] TypeScript type check passes (`npm run tsc`)
- [x] Lint check passes (`npm run lint`)
- [ ] Manual verification of all list pages in browser