### PR TITLE
fix: resolve remaining Ant Design 5.x best practice violations from PR #70

### DIFF
--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Alert, App, Button, ColorPicker, Form, Input, Modal, Popconfirm, Radio, Select, Space, Tag, Table, Tooltip, Typography } from 'antd';
+import { Alert, App, Button, ColorPicker, Divider, Form, Input, Modal, Popconfirm, Radio, Select, Space, Tag, Table, Tooltip, Typography } from 'antd';
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, SelectOutlined, WindowsFilled, AndroidFilled, AppleFilled, QqCircleFilled } from '@ant-design/icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -56,7 +56,6 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
   const intl = useIntl();
   const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   
   const [addPeerModalVisible, setAddPeerModalVisible] = useState(false);
   const [editPeerModalVisible, setEditPeerModalVisible] = useState(false);
@@ -444,7 +443,7 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
       width: 160,
       fixed: "right",
       render: (_: unknown, record: API.PeerItem) => (
-        <Space size="small" split={<span style={{ color: '#ccc' }}>|</span>}>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -747,10 +746,6 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: false,

--- a/src/pages/address-book/personal/index.tsx
+++ b/src/pages/address-book/personal/index.tsx
@@ -54,7 +54,7 @@ export interface PersonalAddressBookProps {
 
 const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGuid, title: propTitle, onBack }) => {
   const intl = useIntl();
-  const { message: msgApi } = App.useApp();
+  const { message: msgApi, modal } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   
   const [addPeerModalVisible, setAddPeerModalVisible] = useState(false);
@@ -461,6 +461,8 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
               />
             }
             onConfirm={() => handleDeletePeer(record.id)}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -510,12 +512,12 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
       key: 'action',
       width: 180,
       render: (_: unknown, record: API.TagItem) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             type="link"
             size="small"
             onClick={() => {
-              Modal.confirm({
+              modal.confirm({
                 title: intl.formatMessage({ id: 'pages.addressBook.renameTag', defaultMessage: 'Rename Tag' }),
                 content: (
                   <Form form={renameTagForm} initialValues={{ old: record.name, new: '' }}>
@@ -543,6 +545,8 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
               />
             }
             onConfirm={() => handleDeleteTag(record.name)}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -577,7 +581,7 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
           color={selectedTags.length === 0 ? 'blue' : undefined}
           onClick={() => { setSelectedTags([]); actionRef.current?.reload(); }}
         >
-          Untagged
+          <FormattedMessage id="pages.addressBook.untagged" defaultMessage="Untagged" />
         </Tag>
         {(tags as API.TagItem[]).map((tag: API.TagItem) => {
           const displayColor = argbToHex(pendingColorUpdates[tag.name] ?? tag.color);
@@ -596,6 +600,8 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
                       defaultMessage="Are you sure to delete this tag?"
                     />
                   }
+                  okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+                  cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
                   onConfirm={(e) => {
                     e?.stopPropagation();
                     handleDeleteTag(tag.name);
@@ -846,7 +852,7 @@ const PersonalAddressBook: React.FC<PersonalAddressBookProps> = ({ guid: propGui
           />
         )}
         <Form form={editPeerForm} onFinish={handleUpdatePeer} layout="vertical">
-          <Form.Item name="id" label="ID">
+          <Form.Item name="id" label={<FormattedMessage id="pages.common.id" defaultMessage="ID" />}>
             <Text>{editingPeer?.id}</Text>
           </Form.Item>
           <Form.Item name="alias" label={<FormattedMessage id="pages.addressBook.alias" defaultMessage="Alias" />}>

--- a/src/pages/address-book/shared/index.tsx
+++ b/src/pages/address-book/shared/index.tsx
@@ -134,6 +134,8 @@ const SharedAddressBook: React.FC = () => {
               />
             }
             onConfirm={() => handleDelete([record.guid])}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -187,6 +189,8 @@ const SharedAddressBook: React.FC = () => {
                 />
               }
               onConfirm={() => handleDelete(selectedRowKeys as string[])}
+              okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+              cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
             >
               <Button danger>
                 <FormattedMessage id="pages.common.batchDelete" defaultMessage="Batch Delete" />

--- a/src/pages/address-book/shared/index.tsx
+++ b/src/pages/address-book/shared/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, history, useIntl } from '@umijs/max';
-import { App, Button, Form, Input, Modal, Popconfirm } from 'antd';
+import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import {
   addSharedAddressBook,
@@ -112,7 +112,7 @@ const SharedAddressBook: React.FC = () => {
       valueType: 'option',
       width: 180,
       render: (_, record) => (
-        <>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -139,7 +139,7 @@ const SharedAddressBook: React.FC = () => {
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
             </Button>
           </Popconfirm>
-        </>
+        </Space>
       ),
     },
   ];
@@ -154,7 +154,7 @@ const SharedAddressBook: React.FC = () => {
         rowKey="guid"
         request={async (params) => {
           const result = await getSharedAddressBooks({
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
             current: params.current || 1,
           });
           return {
@@ -167,6 +167,11 @@ const SharedAddressBook: React.FC = () => {
         rowSelection={{
           selectedRowKeys,
           onChange: setSelectedRowKeys,
+        }}
+        pagination={{
+          defaultPageSize: 20,
+          showSizeChanger: true,
+          showQuickJumper: true,
         }}
         toolBarRender={() => [
           <Button key="create" type="primary" onClick={() => setCreateModalVisible(true)}>
@@ -189,6 +194,15 @@ const SharedAddressBook: React.FC = () => {
             </Popconfirm>
           ),
         ]}
+        options={{
+          density: true,
+          setting: {
+            listsHeight: 400,
+          },
+          fullScreen: false,
+          reload: true,
+        }}
+        scroll={{ x: 800 }}
       />
 
       <Modal

--- a/src/pages/audits/alarm/index.tsx
+++ b/src/pages/audits/alarm/index.tsx
@@ -62,7 +62,7 @@ const AlarmAudit: React.FC = () => {
         request={async (params) => {
           const result = await getAlarmAudits({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -73,7 +73,7 @@ const AlarmAudit: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}

--- a/src/pages/audits/alarm/index.tsx
+++ b/src/pages/audits/alarm/index.tsx
@@ -1,12 +1,11 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
-import { FormattedMessage, useIntl } from '@umijs/max';
+import { FormattedMessage } from '@umijs/max';
 import { Tag } from 'antd';
 import React, { useRef } from 'react';
 import { getAlarmAudits } from '@/services/rustdesk-console/audit';
 
 const AlarmAudit: React.FC = () => {
-  const intl = useIntl();
   const actionRef = useRef<ActionType>(null);
 
   const columns: ProColumns<API.AlarmAuditItem>[] = [

--- a/src/pages/audits/conn/index.tsx
+++ b/src/pages/audits/conn/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Button, message, Tag } from 'antd';
+import { App, Button, Tag } from 'antd';
 import React, { useRef, useState } from 'react';
 import { getConnectionAudits } from '@/services/rustdesk-console/audit';
 import { DownloadOutlined } from '@ant-design/icons';
@@ -9,12 +9,13 @@ import dayjs from 'dayjs';
 
 const ConnectionAudit: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [dataSource, setDataSource] = useState<API.ConnectionAuditItem[]>([]);
 
   const handleExportCSV = () => {
     if (dataSource.length === 0) {
-      message.warning(
+      msgApi.warning(
         intl.formatMessage({
           id: 'pages.audits.noDataToExport',
           defaultMessage: 'No data to export',
@@ -57,7 +58,7 @@ const ConnectionAudit: React.FC = () => {
     link.click();
     URL.revokeObjectURL(link.href);
 
-    message.success(
+    msgApi.success(
       intl.formatMessage({
         id: 'pages.audits.exportSuccess',
         defaultMessage: 'Export successful',

--- a/src/pages/audits/conn/index.tsx
+++ b/src/pages/audits/conn/index.tsx
@@ -81,10 +81,10 @@ const ConnectionAudit: React.FC = () => {
       render: (_: unknown, record: API.ConnectionAuditItem) => {
         const action = record.action || '';
         if (action === 'established') {
-          return <Tag color="green">Established</Tag>;
+          return <Tag color="green"><FormattedMessage id="pages.audits.established" defaultMessage="Established" /></Tag>;
         }
         if (action === 'close') {
-          return <Tag color="red">Closed</Tag>;
+          return <Tag color="red"><FormattedMessage id="pages.audits.closed" defaultMessage="Closed" /></Tag>;
         }
         return <Tag>{action}</Tag>;
       },

--- a/src/pages/audits/console/index.tsx
+++ b/src/pages/audits/console/index.tsx
@@ -43,7 +43,7 @@ const ConsoleAudit: React.FC = () => {
         request={async (params) => {
           const result = await getConsoleAudits({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -54,7 +54,7 @@ const ConsoleAudit: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}
@@ -66,6 +66,7 @@ const ConsoleAudit: React.FC = () => {
           fullScreen: false,
           reload: true,
         }}
+        scroll={{ x: 800 }}
       />
     </PageContainer>
   );

--- a/src/pages/audits/console/index.tsx
+++ b/src/pages/audits/console/index.tsx
@@ -1,11 +1,10 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
-import { FormattedMessage, useIntl } from '@umijs/max';
+import { FormattedMessage } from '@umijs/max';
 import React, { useRef } from 'react';
 import { getConsoleAudits } from '@/services/rustdesk-console/audit';
 
 const ConsoleAudit: React.FC = () => {
-  const intl = useIntl();
   const actionRef = useRef<ActionType>(null);
 
   const columns: ProColumns<API.ConsoleAuditItem>[] = [

--- a/src/pages/audits/file/index.tsx
+++ b/src/pages/audits/file/index.tsx
@@ -40,7 +40,7 @@ const FileAudit: React.FC = () => {
         item.peerId || '',
         item.clientName || '',
         item.clientIp || '',
-        item.type === 0 ? 'Download' : 'Upload',
+        item.type === 0 ? intl.formatMessage({ id: 'pages.audits.download', defaultMessage: 'Download' }) : intl.formatMessage({ id: 'pages.audits.upload', defaultMessage: 'Upload' }),
         item.path || files,
         item.fileCount || 0,
         item.createdAt || '',
@@ -105,10 +105,10 @@ const FileAudit: React.FC = () => {
       search: false,
       render: (_: unknown, record: API.FileAuditItem) => {
         if (record.type === 0) {
-          return <Tag color="green">Download</Tag>;
+          return <Tag color="green"><FormattedMessage id="pages.audits.download" defaultMessage="Download" /></Tag>;
         }
         if (record.type === 1) {
-          return <Tag color="blue">Upload</Tag>;
+          return <Tag color="blue"><FormattedMessage id="pages.audits.upload" defaultMessage="Upload" /></Tag>;
         }
         return <Tag>{record.type}</Tag>;
       },

--- a/src/pages/audits/file/index.tsx
+++ b/src/pages/audits/file/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Button, message, Tag } from 'antd';
+import { App, Button, Tag } from 'antd';
 import React, { useRef, useState } from 'react';
 import { getFileAudits } from '@/services/rustdesk-console/audit';
 import { DownloadOutlined } from '@ant-design/icons';
@@ -9,12 +9,13 @@ import dayjs from 'dayjs';
 
 const FileAudit: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [dataSource, setDataSource] = useState<API.FileAuditItem[]>([]);
 
   const handleExportCSV = () => {
     if (dataSource.length === 0) {
-      message.warning(
+      msgApi.warning(
         intl.formatMessage({
           id: 'pages.audits.noDataToExport',
           defaultMessage: 'No data to export',
@@ -58,7 +59,7 @@ const FileAudit: React.FC = () => {
     link.click();
     URL.revokeObjectURL(link.href);
 
-    message.success(
+    msgApi.success(
       intl.formatMessage({
         id: 'pages.audits.exportSuccess',
         defaultMessage: 'Export successful',

--- a/src/pages/custom-client/index.tsx
+++ b/src/pages/custom-client/index.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage, useIntl } from '@umijs/max';
 import {
   App,
   Button,
+  Divider,
   Form,
   Input,
   Popconfirm,
@@ -117,7 +118,7 @@ const CustomClientList: React.FC = () => {
       width: 250,
       fixed: 'right',
       render: (_, record) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button type="link" size="small" icon={<DownloadOutlined />} onClick={() => handleDownload(record.guid, record.name)}>
             <FormattedMessage id="pages.common.download" defaultMessage="Download" />
           </Button>
@@ -178,7 +179,7 @@ const CustomClientList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.customClients.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter client name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.customClients.enterName', defaultMessage: 'Enter client name' })} />
         </Form.Item>
       </ModalForm>
 
@@ -192,7 +193,7 @@ const CustomClientList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.customClients.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter client name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.customClients.enterName', defaultMessage: 'Enter client name' })} />
         </Form.Item>
       </ModalForm>
     </PageContainer>

--- a/src/pages/custom-client/index.tsx
+++ b/src/pages/custom-client/index.tsx
@@ -6,13 +6,13 @@ import {
   PlusOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
 } from 'antd';
@@ -27,6 +27,7 @@ import {
 
 const CustomClientList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -36,12 +37,12 @@ const CustomClientList: React.FC = () => {
   const handleCreate = async (values: API.CreateCustomClientParams) => {
     try {
       await createCustomClient(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.createSuccess', defaultMessage: 'Custom client created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.createSuccess', defaultMessage: 'Custom client created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.createFailed', defaultMessage: 'Failed to create custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.createFailed', defaultMessage: 'Failed to create custom client' }));
     }
   };
 
@@ -49,23 +50,23 @@ const CustomClientList: React.FC = () => {
     if (!currentClient) return;
     try {
       await updateCustomClient(currentClient.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.updateSuccess', defaultMessage: 'Custom client updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.updateSuccess', defaultMessage: 'Custom client updated' }));
       setEditModalVisible(false);
       setCurrentClient(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.updateFailed', defaultMessage: 'Failed to update custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.updateFailed', defaultMessage: 'Failed to update custom client' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteCustomClient(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.customClients.deleteSuccess', defaultMessage: 'Custom client deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.customClients.deleteSuccess', defaultMessage: 'Custom client deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.deleteFailed', defaultMessage: 'Failed to delete custom client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.deleteFailed', defaultMessage: 'Failed to delete custom client' }));
     }
   };
 
@@ -81,7 +82,7 @@ const CustomClientList: React.FC = () => {
       link.remove();
       window.URL.revokeObjectURL(url);
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.customClients.downloadFailed', defaultMessage: 'Failed to download client' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.customClients.downloadFailed', defaultMessage: 'Failed to download client' }));
     }
   };
 
@@ -130,8 +131,8 @@ const CustomClientList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.customClients.deleteConfirm', defaultMessage: 'Delete this custom client?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -143,7 +144,7 @@ const CustomClientList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.CustomClientItem>
         headerTitle={<FormattedMessage id="pages.customClients.list" defaultMessage="Custom Client List" />}
         actionRef={actionRef}
@@ -194,13 +195,8 @@ const CustomClientList: React.FC = () => {
           <Input placeholder="Enter client name" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default CustomClientList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/device-groups/list/index.tsx
+++ b/src/pages/device-groups/list/index.tsx
@@ -132,6 +132,8 @@ const DeviceGroupList: React.FC = () => {
               />
             }
             onConfirm={() => handleDelete(record.guid)}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />

--- a/src/pages/device-groups/list/index.tsx
+++ b/src/pages/device-groups/list/index.tsx
@@ -1,7 +1,7 @@
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, history, useIntl } from '@umijs/max';
-import { App, Button, Form, Input, Modal, Popconfirm } from 'antd';
+import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import {
   createDeviceGroup,
@@ -110,7 +110,7 @@ const DeviceGroupList: React.FC = () => {
       valueType: 'option',
       width: 180,
       render: (_, record) => (
-        <>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -137,7 +137,7 @@ const DeviceGroupList: React.FC = () => {
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
             </Button>
           </Popconfirm>
-        </>
+        </Space>
       ),
     },
   ];
@@ -153,7 +153,7 @@ const DeviceGroupList: React.FC = () => {
         request={async (params) => {
           const result = await getDeviceGroupList({
             current: params.current || 1,
-            pageSize: params.pageSize || 10,
+            pageSize: params.pageSize || 20,
           });
           return {
             data: result.data || [],
@@ -164,7 +164,7 @@ const DeviceGroupList: React.FC = () => {
         columns={columns}
         search={false}
         pagination={{
-          defaultPageSize: 10,
+          defaultPageSize: 20,
           showSizeChanger: true,
           showQuickJumper: true,
         }}
@@ -176,6 +176,15 @@ const DeviceGroupList: React.FC = () => {
             />
           </Button>,
         ]}
+        options={{
+          density: true,
+          setting: {
+            listsHeight: 400,
+          },
+          fullScreen: false,
+          reload: true,
+        }}
+        scroll={{ x: 800 }}
       />
 
       <Modal

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -14,7 +14,7 @@ import { removeDeviceFromGroup } from '@/services/rustdesk-console/deviceGroup';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { App, Button, Popconfirm, Space } from 'antd';
+import { App, Button, Divider, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Settings from '../../../../config/defaultSettings';
@@ -30,8 +30,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
   const intl = useIntl();
   const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
-  const [totalDevices, setTotalDevices] = useState<number>(0);
 
   const handleEnable = async (guid: string) => {
     try {
@@ -152,7 +150,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
       
       // Normal device list (not in device group context)
       return (
-        <Space size="small" split={<span style={{ color: '#ccc' }}>|</span>}>
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button key="edit" type="link" size="small" icon={<EditOutlined />}>
             <FormattedMessage id="pages.common.edit" defaultMessage="Edit" />
           </Button>
@@ -215,13 +213,10 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
       >
       <ProTable<API.DeviceItem>
         headerTitle={
-          <span>
-            <FormattedMessage
-              id="pages.devices.list"
-              defaultMessage="Device List"
-            />{' '}
-            ({totalDevices}/-)
-          </span>
+          <FormattedMessage
+            id="pages.devices.list"
+            defaultMessage="Device List"
+          />
         }
         actionRef={actionRef}
         rowKey="guid"
@@ -237,7 +232,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
             device_group_guid: deviceGroupGuid,
             os: params.os,
           });
-          setTotalDevices(result.total || 0);
           return {
             data: result.data || [],
             total: result.total || 0,
@@ -245,10 +239,6 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: true,

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -140,6 +140,8 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
               />
             }
             onConfirm={() => handleRemoveFromGroup(record.id)}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.devices.remove" defaultMessage="Remove" />
@@ -185,6 +187,8 @@ const DeviceList: React.FC<DeviceListProps> = ({ deviceGroupGuid, title, onBack 
                 />
               }
               onConfirm={() => handleDelete(record.guid)}
+              okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+              cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
             >
               <Button type="link" size="small" danger icon={<DeleteOutlined />}>
                 <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />

--- a/src/pages/groups/user/index.tsx
+++ b/src/pages/groups/user/index.tsx
@@ -5,13 +5,13 @@ import {
   TeamOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
 } from 'antd';
@@ -25,6 +25,7 @@ import {
 
 const UserGroupList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -34,12 +35,12 @@ const UserGroupList: React.FC = () => {
   const handleCreate = async (values: API.CreateUserGroupParams) => {
     try {
       await createUserGroup(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.createSuccess', defaultMessage: 'User group created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.createSuccess', defaultMessage: 'User group created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.createFailed', defaultMessage: 'Failed to create user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.createFailed', defaultMessage: 'Failed to create user group' }));
     }
   };
 
@@ -47,23 +48,23 @@ const UserGroupList: React.FC = () => {
     if (!currentGroup) return;
     try {
       await updateUserGroup(currentGroup.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.updateSuccess', defaultMessage: 'User group updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.updateSuccess', defaultMessage: 'User group updated' }));
       setEditModalVisible(false);
       setCurrentGroup(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.updateFailed', defaultMessage: 'Failed to update user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.updateFailed', defaultMessage: 'Failed to update user group' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteUserGroup(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.userGroups.deleteSuccess', defaultMessage: 'User group deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.userGroups.deleteSuccess', defaultMessage: 'User group deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.userGroups.deleteFailed', defaultMessage: 'Failed to delete user group' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.userGroups.deleteFailed', defaultMessage: 'Failed to delete user group' }));
     }
   };
 
@@ -115,8 +116,8 @@ const UserGroupList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.userGroups.deleteConfirm', defaultMessage: 'Delete this user group?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -128,7 +129,7 @@ const UserGroupList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.UserGroupItem>
         headerTitle={<FormattedMessage id="pages.userGroups.list" defaultMessage="User Group List" />}
         actionRef={actionRef}
@@ -185,13 +186,8 @@ const UserGroupList: React.FC = () => {
           <Input.TextArea rows={3} placeholder="Enter description" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default UserGroupList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/groups/user/index.tsx
+++ b/src/pages/groups/user/index.tsx
@@ -10,6 +10,7 @@ import { FormattedMessage, useIntl } from '@umijs/max';
 import {
   App,
   Button,
+  Divider,
   Form,
   Input,
   Popconfirm,
@@ -105,7 +106,7 @@ const UserGroupList: React.FC = () => {
       width: 180,
       fixed: 'right',
       render: (_, record) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button type="link" size="small" icon={<EditOutlined />} onClick={() => {
             setCurrentGroup(record);
             form.setFieldsValue(record);
@@ -163,10 +164,10 @@ const UserGroupList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.userGroups.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter group name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.userGroups.enterName', defaultMessage: 'Enter group name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.userGroups.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
       </ModalForm>
 
@@ -180,10 +181,10 @@ const UserGroupList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.userGroups.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter group name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.userGroups.enterName', defaultMessage: 'Enter group name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.userGroups.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
       </ModalForm>
     </PageContainer>

--- a/src/pages/roles/index.tsx
+++ b/src/pages/roles/index.tsx
@@ -6,14 +6,14 @@ import {
   SafetyCertificateOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Checkbox,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
   Tag,
@@ -31,6 +31,7 @@ import {
 
 const RoleList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -50,14 +51,14 @@ const RoleList: React.FC = () => {
   const handleCreate = async (values: API.CreateRoleParams) => {
     try {
       await createRole(values);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.createSuccess', defaultMessage: 'Role created successfully' }),
       );
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.createFailed', defaultMessage: 'Failed to create role' }),
       );
     }
@@ -67,7 +68,7 @@ const RoleList: React.FC = () => {
     if (!currentRole) return;
     try {
       await updateRole(currentRole.guid, values);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.updateSuccess', defaultMessage: 'Role updated successfully' }),
       );
       setEditModalVisible(false);
@@ -75,7 +76,7 @@ const RoleList: React.FC = () => {
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.updateFailed', defaultMessage: 'Failed to update role' }),
       );
     }
@@ -84,12 +85,12 @@ const RoleList: React.FC = () => {
   const handleDelete = async (guid: string) => {
     try {
       await deleteRole(guid);
-      messageApi.success(
+      msgApi.success(
         intl.formatMessage({ id: 'pages.roles.deleteSuccess', defaultMessage: 'Role deleted successfully' }),
       );
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(
+      msgApi.error(
         intl.formatMessage({ id: 'pages.roles.deleteFailed', defaultMessage: 'Failed to delete role' }),
       );
     }
@@ -118,7 +119,7 @@ const RoleList: React.FC = () => {
       width: 200,
       render: (_, record) => (
         <Space>
-          <SafetyCertificateOutlined style={{ color: '#1890ff' }} />
+          <SafetyCertificateOutlined style={{ color: '#1677ff' }} />
           <span>{record.name}</span>
         </Space>
       ),
@@ -203,7 +204,7 @@ const RoleList: React.FC = () => {
   };
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.RoleItem>
         headerTitle={
           <FormattedMessage id="pages.roles.list" defaultMessage="Role List" />
@@ -329,13 +330,8 @@ const RoleList: React.FC = () => {
           </Checkbox.Group>
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default RoleList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/roles/index.tsx
+++ b/src/pages/roles/index.tsx
@@ -12,6 +12,7 @@ import {
   App,
   Button,
   Checkbox,
+  Divider,
   Form,
   Input,
   Popconfirm,
@@ -151,7 +152,7 @@ const RoleList: React.FC = () => {
       width: 180,
       fixed: 'right',
       render: (_, record) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -164,8 +165,8 @@ const RoleList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.roles.deleteConfirm', defaultMessage: 'Are you sure to delete this role?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText={intl.formatMessage({ id: 'pages.common.yes', defaultMessage: 'Yes' })}
-            cancelText={intl.formatMessage({ id: 'pages.common.no', defaultMessage: 'No' })}
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button key="delete" type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -274,7 +275,7 @@ const RoleList: React.FC = () => {
           <Input placeholder={intl.formatMessage({ id: 'pages.common.pleaseEnterRoleName', defaultMessage: 'Please enter role name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.roles.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter role description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
         <Form.Item
           name="permissions"
@@ -313,7 +314,7 @@ const RoleList: React.FC = () => {
           <Input placeholder={intl.formatMessage({ id: 'pages.common.pleaseEnterRoleName', defaultMessage: 'Please enter role name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.roles.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter role description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
         <Form.Item
           name="permissions"

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,12 +1,12 @@
 import { SaveOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Card,
   Form,
   Input,
-  message as messageApi,
   Select,
   Space,
   Switch,
@@ -17,6 +17,7 @@ import { getSettings, updateSetting } from '@/services/rustdesk-console/settings
 
 const Settings: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState('general');
@@ -38,7 +39,7 @@ const Settings: React.FC = () => {
       }
     } catch (error) {
       console.error('Failed to fetch settings:', error);
-      messageApi.error(intl.formatMessage({ id: 'pages.settings.fetchFailed', defaultMessage: 'Failed to load settings' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.settings.fetchFailed', defaultMessage: 'Failed to load settings' }));
     } finally {
       setLoading(false);
     }
@@ -52,9 +53,9 @@ const Settings: React.FC = () => {
           updateSetting(key, value as string | number | boolean)
         )
       );
-      messageApi.success(intl.formatMessage({ id: 'pages.settings.saveSuccess', defaultMessage: 'Settings saved successfully' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.settings.saveSuccess', defaultMessage: 'Settings saved successfully' }));
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.settings.saveFailed', defaultMessage: 'Failed to save settings' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.settings.saveFailed', defaultMessage: 'Failed to save settings' }));
     }
   };
 
@@ -126,8 +127,3 @@ const Settings: React.FC = () => {
 };
 
 export default Settings;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -78,13 +78,13 @@ const Settings: React.FC = () => {
             children: (
               <Form form={form} layout="vertical" style={{ marginTop: 24 }}>
                 <Form.Item name="site_name" label={<FormattedMessage id="pages.settings.siteName" defaultMessage="Site Name" />}>
-                  <Input placeholder="Enter site name" />
+                  <Input placeholder={intl.formatMessage({ id: 'pages.settings.enterSiteName', defaultMessage: 'Enter site name' })} />
                 </Form.Item>
                 <Form.Item name="admin_email" label={<FormattedMessage id="pages.settings.adminEmail" defaultMessage="Admin Email" />}>
-                  <Input placeholder="Enter admin email" />
+                  <Input placeholder={intl.formatMessage({ id: 'pages.settings.enterAdminEmail', defaultMessage: 'Enter admin email' })} />
                 </Form.Item>
                 <Form.Item name="language" label={<FormattedMessage id="pages.settings.language" defaultMessage="Default Language" />}>
-                  <Select options={[{ value: 'en', label: 'English' }, { value: 'zh', label: 'Chinese' }]} />
+                  <Select options={[{ value: 'en', label: intl.formatMessage({ id: 'pages.settings.english', defaultMessage: 'English' }) }, { value: 'zh', label: intl.formatMessage({ id: 'pages.settings.chinese', defaultMessage: 'Chinese' }) }]} />
                 </Form.Item>
               </Form>
             ),
@@ -112,7 +112,7 @@ const Settings: React.FC = () => {
             children: (
               <Form form={form} layout="vertical" style={{ marginTop: 24 }}>
                 <Form.Item name="log_level" label={<FormattedMessage id="pages.settings.logLevel" defaultMessage="Log Level" />}>
-                  <Select options={[{ value: 'info', label: 'Info' }, { value: 'warn', label: 'Warning' }, { value: 'error', label: 'Error' }]} />
+                  <Select options={[{ value: 'info', label: intl.formatMessage({ id: 'pages.settings.logInfo', defaultMessage: 'Info' }) }, { value: 'warn', label: intl.formatMessage({ id: 'pages.settings.logWarning', defaultMessage: 'Warning' }) }, { value: 'error', label: intl.formatMessage({ id: 'pages.settings.logError', defaultMessage: 'Error' }) }]} />
                 </Form.Item>
                 <Form.Item name="enable_debug_mode" label={<FormattedMessage id="pages.settings.enableDebugMode" defaultMessage="Enable Debug Mode" />} valuePropName="checked">
                   <Switch />

--- a/src/pages/strategy/index.tsx
+++ b/src/pages/strategy/index.tsx
@@ -5,13 +5,13 @@ import {
   SolutionOutlined,
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
-import { ModalForm, ProTable } from '@ant-design/pro-components';
-import { useIntl } from '@umijs/max';
+import { ModalForm, PageContainer, ProTable } from '@ant-design/pro-components';
+import { FormattedMessage, useIntl } from '@umijs/max';
 import {
+  App,
   Button,
   Form,
   Input,
-  message as messageApi,
   Popconfirm,
   Space,
   Switch,
@@ -26,6 +26,7 @@ import {
 
 const StrategyList: React.FC = () => {
   const intl = useIntl();
+  const { message: msgApi } = App.useApp();
   const actionRef = useRef<ActionType>(null);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -35,12 +36,12 @@ const StrategyList: React.FC = () => {
   const handleCreate = async (values: API.CreateStrategyParams) => {
     try {
       await createStrategy(values);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.createSuccess', defaultMessage: 'Strategy created' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.createSuccess', defaultMessage: 'Strategy created' }));
       setCreateModalVisible(false);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.createFailed', defaultMessage: 'Failed to create strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.createFailed', defaultMessage: 'Failed to create strategy' }));
     }
   };
 
@@ -48,23 +49,23 @@ const StrategyList: React.FC = () => {
     if (!currentStrategy) return;
     try {
       await updateStrategy(currentStrategy.guid, values);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.updateSuccess', defaultMessage: 'Strategy updated' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.updateSuccess', defaultMessage: 'Strategy updated' }));
       setEditModalVisible(false);
       setCurrentStrategy(null);
       form.resetFields();
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.updateFailed', defaultMessage: 'Failed to update strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.updateFailed', defaultMessage: 'Failed to update strategy' }));
     }
   };
 
   const handleDelete = async (guid: string) => {
     try {
       await deleteStrategy(guid);
-      messageApi.success(intl.formatMessage({ id: 'pages.strategies.deleteSuccess', defaultMessage: 'Strategy deleted' }));
+      msgApi.success(intl.formatMessage({ id: 'pages.strategies.deleteSuccess', defaultMessage: 'Strategy deleted' }));
       actionRef.current?.reload();
     } catch (error) {
-      messageApi.error(intl.formatMessage({ id: 'pages.strategies.deleteFailed', defaultMessage: 'Failed to delete strategy' }));
+      msgApi.error(intl.formatMessage({ id: 'pages.strategies.deleteFailed', defaultMessage: 'Failed to delete strategy' }));
     }
   };
 
@@ -119,8 +120,8 @@ const StrategyList: React.FC = () => {
           <Popconfirm
             title={intl.formatMessage({ id: 'pages.strategies.deleteConfirm', defaultMessage: 'Delete this strategy?' })}
             onConfirm={() => handleDelete(record.guid)}
-            okText="Yes"
-            cancelText="No"
+            okText={intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' })}
+            cancelText={intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' })}
           >
             <Button type="link" size="small" danger icon={<DeleteOutlined />}>
               <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
@@ -132,7 +133,7 @@ const StrategyList: React.FC = () => {
   ];
 
   return (
-    <>
+    <PageContainer>
       <ProTable<API.StrategyItem>
         headerTitle={<FormattedMessage id="pages.strategies.list" defaultMessage="Strategy List" />}
         actionRef={actionRef}
@@ -189,13 +190,8 @@ const StrategyList: React.FC = () => {
           <Input.TextArea rows={3} placeholder="Enter description" />
         </Form.Item>
       </ModalForm>
-    </>
+    </PageContainer>
   );
 };
 
 export default StrategyList;
-
-function FormattedMessage(props: { id: string; defaultMessage?: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/strategy/index.tsx
+++ b/src/pages/strategy/index.tsx
@@ -10,6 +10,7 @@ import { FormattedMessage, useIntl } from '@umijs/max';
 import {
   App,
   Button,
+  Divider,
   Form,
   Input,
   Popconfirm,
@@ -109,7 +110,7 @@ const StrategyList: React.FC = () => {
       width: 180,
       fixed: 'right',
       render: (_, record) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button type="link" size="small" icon={<EditOutlined />} onClick={() => {
             setCurrentStrategy(record);
             form.setFieldsValue(record);
@@ -167,10 +168,10 @@ const StrategyList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.strategies.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter strategy name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.strategies.enterName', defaultMessage: 'Enter strategy name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.strategies.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
       </ModalForm>
 
@@ -184,10 +185,10 @@ const StrategyList: React.FC = () => {
         modalProps={{ destroyOnClose: true }}
       >
         <Form.Item name="name" label={<FormattedMessage id="pages.strategies.name" defaultMessage="Name" />} rules={[{ required: true }]}>
-          <Input placeholder="Enter strategy name" />
+          <Input placeholder={intl.formatMessage({ id: 'pages.strategies.enterName', defaultMessage: 'Enter strategy name' })} />
         </Form.Item>
         <Form.Item name="note" label={<FormattedMessage id="pages.strategies.note" defaultMessage="Note" />}>
-          <Input.TextArea rows={3} placeholder="Enter description" />
+          <Input.TextArea rows={3} placeholder={intl.formatMessage({ id: 'pages.common.enterDescription', defaultMessage: 'Enter description' })} />
         </Form.Item>
       </ModalForm>
     </PageContainer>

--- a/src/pages/users/list/index.tsx
+++ b/src/pages/users/list/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@ant-design/icons';
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
-import { useIntl, useModel } from '@umijs/max';
+import { FormattedMessage, useIntl, useModel } from '@umijs/max';
 import {
   App,
   Button,
@@ -43,7 +43,6 @@ const UserList: React.FC = () => {
   const [inviteModalVisible, setInviteModalVisible] = useState(false);
   const [createForm] = Form.useForm();
   const [inviteForm] = Form.useForm();
-  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [searchParams, setSearchParams] = useState<{
     search?: string;
     status?: string;
@@ -303,10 +302,7 @@ const UserList: React.FC = () => {
     <PageContainer>
       <ProTable<API.UserItem>
         headerTitle={
-          <span>
-            <FormattedMessage id="pages.users.list" defaultMessage="User List" /> {' '}
-            {searchParams.search ? '*' : '0'}/-
-          </span>
+          <FormattedMessage id="pages.users.list" defaultMessage="User List" />
         }
         actionRef={actionRef}
         rowKey="guid"
@@ -324,10 +320,6 @@ const UserList: React.FC = () => {
           };
         }}
         columns={columns}
-        rowSelection={{
-          selectedRowKeys,
-          onChange: setSelectedRowKeys,
-        }}
         search={{
           labelWidth: 'auto',
           defaultCollapsed: false,
@@ -432,8 +424,3 @@ const UserList: React.FC = () => {
 };
 
 export default UserList;
-
-function FormattedMessage(props: { id: string; defaultMessage: string }): React.JSX.Element {
-  const intl = useIntl();
-  return <>{intl.formatMessage(props)}</>;
-}

--- a/src/pages/users/list/index.tsx
+++ b/src/pages/users/list/index.tsx
@@ -13,11 +13,11 @@ import { FormattedMessage, useIntl, useModel } from '@umijs/max';
 import {
   App,
   Button,
+  Divider,
   Dropdown,
   Form,
   Input,
   Modal,
-  Popconfirm,
   Space,
   Switch,
   Tag,
@@ -35,7 +35,7 @@ import {
 
 const UserList: React.FC = () => {
   const intl = useIntl();
-  const { message: msgApi } = App.useApp();
+  const { message: msgApi, modal } = App.useApp();
   const { initialState } = useModel('@@initialState');
   const currentUser = initialState?.currentUser;
   const actionRef = useRef<ActionType>(null);
@@ -142,12 +142,12 @@ const UserList: React.FC = () => {
         <Space>
           <span>{record.name}</span>
           {record.is_admin && (
-            <Tooltip title="Admin">
+            <Tooltip title={intl.formatMessage({ id: 'pages.users.admin', defaultMessage: 'Admin' })}>
               <CrownOutlined style={{ color: '#faad14' }} />
             </Tooltip>
           )}
           {record.name === currentUser?.name && (
-            <Tag color="blue">Me</Tag>
+            <Tag color="blue"><FormattedMessage id="pages.users.me" defaultMessage="Me" /></Tag>
           )}
         </Space>
       ),
@@ -198,7 +198,7 @@ const UserList: React.FC = () => {
       search: false,
       render: (_: unknown, record: API.UserItem) =>
         record.is_admin ? (
-          <Tag color="blue">Admin</Tag>
+          <Tag color="blue"><FormattedMessage id="pages.users.admin" defaultMessage="Admin" /></Tag>
         ) : (
           <span>-</span>
         ),
@@ -245,7 +245,7 @@ const UserList: React.FC = () => {
       width: 180,
       fixed: 'right',
       render: (_: unknown, record: API.UserItem) => (
-        <Space size="small">
+        <Space size={0} split={<Divider type="vertical" />}>
           <Button
             key="edit"
             type="link"
@@ -279,12 +279,17 @@ const UserList: React.FC = () => {
                 {
                   key: 'delete',
                   label: (
-                    <span style={{ color: '#ff4d4f' }}>
-                      <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
-                    </span>
+                    <FormattedMessage id="pages.common.delete" defaultMessage="Delete" />
                   ),
                   danger: true,
-                  onClick: () => handleDelete(record.guid),
+                  onClick: () => {
+                    modal.confirm({
+                      title: intl.formatMessage({ id: 'pages.users.deleteConfirm', defaultMessage: 'Are you sure to delete this user?' }),
+                      okText: intl.formatMessage({ id: 'pages.common.confirm', defaultMessage: 'Yes' }),
+                      cancelText: intl.formatMessage({ id: 'pages.common.cancel', defaultMessage: 'No' }),
+                      onOk: () => handleDelete(record.guid),
+                    });
+                  },
                 },
               ],
             }}


### PR DESCRIPTION
## Summary

Fix remaining Ant Design 5.x best practice violations identified during review of PR #70. While PR #70 correctly addressed the core structural issues (message API, PageContainer, FormattedMessage imports, pagination, scroll, rowSelection), several i18n and API usage issues remained.

## Changes

### Critical Fixes
- **Replace `Modal.confirm` static method with `App.useApp()` `modal.confirm()`** in personal address book and users list pages — static methods don't support ConfigProvider context in Ant Design 5.x

### Medium Fixes
- **Add `okText`/`cancelText` i18n to all Popconfirm components** across personal, shared, device-groups, and devices pages
- **Replace hardcoded English strings with `FormattedMessage`/`intl.formatMessage()`** for "Untagged", "Established"/"Closed", "Download"/"Upload", "Admin", "Me"
- **Replace hardcoded placeholders with `intl.formatMessage()`** in custom-client, user groups, roles, strategy, and settings pages
- **Replace hardcoded Select option labels with `intl.formatMessage()`** in settings page
- **Add delete confirmation dialog for users list** (was missing — delete executed directly without confirmation)
- **Remove redundant `style={{ color: '#ff4d4f' }}` alongside `danger` prop** in users list

### Low Fixes
- **Unify action column separators to `Space size={0} split={<Divider type="vertical" />}`** across custom-client, user groups, roles, strategy, and users pages
- **Unify Popconfirm `okText`/`cancelText` i18n keys** to `pages.common.confirm`/`pages.common.cancel` (was inconsistent: some used `yes`/`no`)
- **Remove unused `useIntl` imports** in alarm and console audit pages
- **Remove unused `Popconfirm` import** in users list

## Test Plan
- [x] TypeScript type check passes (`npm run tsc`)
- [x] Lint check passes (`npm run lint`)
- [ ] Manual verification of all list pages in browser