### PR TITLE
chore: remove unused @antv/l7 and @antv/l7-react packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "@ant-design/plots": "^2.6.0",
     "@ant-design/pro-components": "^2.7.19",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
-    "@antv/l7": "^2.22.7",
-    "@antv/l7-react": "^2.4.3",
     "antd": "^5.25.4",
     "antd-style": "^3.7.0",
     "classnames": "^2.5.1",


### PR DESCRIPTION
## Summary

- Remove `@antv/l7` and `@antv/l7-react` from dependencies
- These packages are declared but never imported or used in the codebase
- Eliminates the peer dependency conflict with React 19 (`@antv/l7-react` requires React 16/17)

## Test plan

- [ ] Verify `npm install` completes without peer dependency errors
- [ ] Verify build succeeds
- [ ] Verify no runtime errors related to missing l7 packages