### PR TITLE
fix: enable toolbar options for device list table

### DIFF
--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -297,7 +297,7 @@ const DeviceList: React.FC<DeviceListProps> = ({
             showQuickJumper: true,
           }}
           scroll={{ x: '100%' }}
-          toolBarRender={false}
+          toolBarRender={() => []}
           options={{
             density: true,
             setting: {


### PR DESCRIPTION
## Summary

- Change `toolBarRender` from `false` to empty array `()\ => []`
- Enable density control, column settings, and reload options for device list table
- Align with Ant Design Pro best practices

## Problem

The device list table had `toolBarRender={false}`, which completely hides the toolbar area. This prevented users from:
- Controlling table row density (default/medium/compact)
- Showing/hiding columns
- Manually refreshing the table

## Solution

Changed `toolBarRender` to return an empty array, which keeps the toolbar area visible but without custom buttons. This allows the `options` configuration (density, setting, reload) to work properly.

## Changes

- `src/pages/devices/list/index.tsx`: Changed `toolBarRender={false}` to `toolBarRender={() => []}`

## Test

- [x] Code compiles without errors
- [x] Toolbar options (density, column settings, reload) are now visible
- [x] Consistent with other list implementations (device groups, address book)