### PR TITLE
fix(deploy): set correct publicPath for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+          GITHUB_PAGES: true
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+          GITHUB_PAGES: true
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -107,6 +108,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
+          GITHUB_PAGES: true
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/config/config.ts
+++ b/config/config.ts
@@ -6,7 +6,9 @@ import routes from './routes';
 
 const { REACT_APP_ENV = 'dev' } = process.env;
 
-const PUBLIC_PATH: string = '/';
+const PUBLIC_PATH: string = process.env.GITHUB_PAGES
+  ? '/rustdesk-console-web/'
+  : '/';
 
 export default defineConfig({
   hash: true,


### PR DESCRIPTION
## Summary

- Fix 404 errors for static assets on GitHub Pages
- Add GITHUB_PAGES environment variable check in config
- Set publicPath to `/rustdesk-console-web/` for GitHub Pages deployment
- Keep publicPath as `/` for local development

## Problem

When deploying to GitHub Pages, the application was requesting resources from:
- `https://databk.github.io/umi.xxx.css` ❌
- `https://databk.github.io/umi.xxx.js` ❌

But the correct paths should be:
- `https://databk.github.io/rustdesk-console-web/umi.xxx.css` ✅
- `https://databk.github.io/rustdesk-console-web/umi.xxx.js` ✅

## Solution

Modified `config/config.ts` to dynamically set `publicPath` based on the `GITHUB_PAGES` environment variable:

```typescript
const PUBLIC_PATH: string = process.env.GITHUB_PAGES
  ? '/rustdesk-console-web/'
  : '/';
```

Updated workflows to set `GITHUB_PAGES=true` during build:
- `.github/workflows/deploy.yml`
- `.github/workflows/release.yml`

## Test Plan

- [ ] Verify local development still works with `publicPath: '/'`
- [ ] Deploy to GitHub Pages and verify assets load correctly
- [ ] Check that all routes work with hash routing