### PR TITLE
chore(deps): add dependabot configuration for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "yuzhiyuan"
+    assignees:
+      - "yuzhiyuan"
+    versioning-strategy: "increase-if-necessary"
+    ignore:
+      - dependency-name: "react"
+        versions: ["20.x"]
+      - dependency-name: "react-dom"
+        versions: ["20.x"]
+      - dependency-name: "antd"
+        versions: ["6.x"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "yuzhiyuan"
+    assignees:
+      - "yuzhiyuan"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,9 @@ updates:
     labels:
       - "dependencies"
     reviewers:
-      - "yuzhiyuan"
+      - "YuZhiYuanDev"
     assignees:
-      - "yuzhiyuan"
+      - "YuZhiYuanDev"
     versioning-strategy: "increase-if-necessary"
     ignore:
       - dependency-name: "react"
@@ -41,9 +41,9 @@ updates:
       - "dependencies"
       - "github-actions"
     reviewers:
-      - "yuzhiyuan"
+      - "YuZhiYuanDev"
     assignees:
-      - "yuzhiyuan"
+      - "YuZhiYuanDev"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automate dependency updates for:

- **npm**: Weekly checks for npm package updates
- **github-actions**: Weekly checks for GitHub Actions updates

## Configuration Details

### npm
- Schedule: Weekly on Monday at 09:00 (Asia/Shanghai)
- Max open PRs: 10
- Commit prefix: `chore(deps)`
- Ignores major version upgrades for React 20.x and antd 6.x

### github-actions
- Schedule: Weekly on Monday at 09:00 (Asia/Shanghai)
- Max open PRs: 5
- Commit prefix: `ci(deps)`
- Groups all action updates into single PR

## Test Plan

- [ ] Verify Dependabot starts creating PRs after merge
- [ ] Check that ignored versions are respected