### PR TITLE
fix(tsconfig): resolve TypeScript deprecation warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "baseUrl": "./",
     "target": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary
- Update `moduleResolution` from `'node'` to `'bundler'` for modern bundler compatibility
- Add `ignoreDeprecations: '5.0'` to suppress `baseUrl` deprecation warning

## Problem
The CI was failing with TypeScript deprecation warnings:
- `baseUrl` option is deprecated in TypeScript 7.0
- `moduleResolution=node10` is deprecated in TypeScript 7.0

## Solution
1. Changed `moduleResolution` to `'bundler'` which is the recommended setting for projects using modern bundlers like webpack (used by UmiJS)
2. Added `ignoreDeprecations: '5.0'` to temporarily suppress the `baseUrl` deprecation warning since it's still required for path aliases

## Testing
- ✅ TypeScript type check passes (`npx tsc --noEmit`)
- ✅ No breaking changes to existing functionality

Fixes CI type check errors in PR #52