### PR TITLE
fix(tsconfig): migrate deprecated baseUrl and moduleResolution options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "target": "esnext",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary

- Remove deprecated `baseUrl` option (TS5101) from `tsconfig.json`
- Update `moduleResolution` from `"node"` (node10) to `"bundler"` (TS5107)
- Add `module: "esnext"` to align with the bundler resolution strategy

## Details

The CI `npx tsc --noEmit` check was failing with:

- **TS5101**: `baseUrl` is deprecated and will stop functioning in TypeScript 7.0
- **TS5107**: `moduleResolution: node10` is deprecated and will stop functioning in TypeScript 7.0

Path aliases in `paths` are already specified as project-root-relative paths (e.g. `"@/*": ["./src/*"]`), so removing `baseUrl` requires no further changes.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] No `ignoreDeprecations` workaround used — this is a proper migration