### PR TITLE
chore: prepare for v1.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]+.*'
 
 concurrency:
   group: release-${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Determine version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Download build artifact
         uses: actions/download-artifact@v8
@@ -63,22 +63,22 @@ jobs:
       - name: Create release archive
         run: |
           cd dist
-          tar -czf ../rustdesk-console-web-v${{ steps.version.outputs.version }}.tar.gz .
+          tar -czf ../rustdesk-console-web-${{ steps.version.outputs.version }}.tar.gz .
           cd ..
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: v${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           body: |
-            ## rustdesk-console-web v${{ steps.version.outputs.version }}
+            ## rustdesk-console-web ${{ steps.version.outputs.version }}
 
             ### Changes
             See [commit history](https://github.com/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}) for details.
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           files: |
-            rustdesk-console-web-v${{ steps.version.outputs.version }}.tar.gz
+            rustdesk-console-web-${{ steps.version.outputs.version }}.tar.gz
           discussion_category_name: Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RustDesk Console Web
 
-Web frontend for [RustDesk](https://rustdesk.com) Console, built with [Ant Design Pro](https://pro.ant.design) and [UmiJS](https://umijs.org).
+Web frontend for [RustDesk Console](https://github.com/databk/rustdesk-console), built with [Ant Design Pro](https://pro.ant.design) and [UmiJS](https://umijs.org).
 
 ## Features
 
@@ -53,4 +53,4 @@ npm run preview
 
 ## License
 
-[AGPL-3.0-or-later](LICENSE)
+[AGPL-3.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,57 +1,56 @@
-# Ant Design Pro
+# RustDesk Console Web
 
-This project is initialized with [Ant Design Pro](https://pro.ant.design). Follow is the quick guide for how to use.
+Web frontend for [RustDesk](https://rustdesk.com) Console, built with [Ant Design Pro](https://pro.ant.design) and [UmiJS](https://umijs.org).
 
-## Environment Prepare
+## Features
 
-Install `node_modules`:
+- Device management
+- User and address book management
+- Group and permission management
+- Activity monitoring and statistics
+- Multi-language support
+
+## Prerequisites
+
+- Node.js >= 20.0.0
+
+## Getting Started
+
+Install dependencies:
 
 ```bash
 npm install
 ```
 
-or
+Start development server:
 
 ```bash
-yarn
+npm run dev
 ```
 
-## Provided Scripts
-
-Ant Design Pro provides some useful script to help you quick start and build with web project, code style check and test.
-
-Scripts provided in `package.json`. It's safe to modify or add additional script:
-
-### Start project
-
-```bash
-npm start
-```
-
-### Build project
+Build for production:
 
 ```bash
 npm run build
 ```
 
-### Check code style
+Preview production build:
 
 ```bash
-npm run lint
+npm run preview
 ```
 
-You can also use script to auto fix some lint error:
+## Available Scripts
 
-```bash
-npm run lint:fix
-```
+| Script            | Description                            |
+| ----------------- | -------------------------------------- |
+| `npm run dev`     | Start dev server (connects to dev API) |
+| `npm start`       | Start dev server with mock data        |
+| `npm run build`   | Build for production                   |
+| `npm run preview` | Build and preview locally              |
+| `npm run lint`    | Run linter (Biome + TypeScript)        |
+| `npm test`        | Run tests                              |
 
-### Test code
+## License
 
-```bash
-npm test
-```
-
-## More
-
-You can view full document on our [official website](https://pro.ant.design). And welcome any feedback in our [github](https://github.com/ant-design/ant-design-pro).
+[AGPL-3.0-or-later](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
   "name": "rustdesk-console-web",
   "version": "1.0.0",
-  "private": true,
+  "private": false,
   "description": "RustDesk Console Web Application",
+  "homepage": "https://databk.github.io/rustdesk-console-web/",
+  "bugs": {
+    "url": "https://github.com/databk/rustdesk-console-web/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/databk/rustdesk-console-web.git"
+  },
+  "license": "AGPL-3.0-or-later",
+  "author": "databk",
   "scripts": {
     "analyze": "cross-env ANALYZE=1 max build",
     "biome:lint": "npx @biomejs/biome lint",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/databk/rustdesk-console-web.git"
   },
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0",
   "author": "databk",
   "scripts": {
     "analyze": "cross-env ANALYZE=1 max build",


### PR DESCRIPTION
## Changes

Prepare the project for the first public release (1.0.0).

### package.json
- Add `author`, `license`, `repository`, `homepage`, `bugs` metadata
- Change `private` from `true` to `false` for open-source publishing

### .github/workflows/release.yml
- Change tag pattern from `v*` to `[0-9]+.*` to match version tags without v prefix (e.g. `1.0.0` instead of `v1.0.0`)
- Remove v prefix from version extraction, release name, archive filename, and release body

### README.md
- Replace Ant Design Pro template content with project-specific documentation