### PR TITLE
feat: add Docker image publishing to GHCR and Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,11 +3,8 @@ dist
 .git
 .github
 .husky
-.arts
-.codeartsdoer
-.continue
-.playwright-cli
-.trae
-*.md
-LICENSE
 .gitignore
+.dockerignore
+*.md
+!README.md
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.git
+.github
+.husky
+.arts
+.codeartsdoer
+.continue
+.playwright-cli
+.trae
+*.md
+LICENSE
+.gitignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: write
   discussions: write
+  packages: write
 
 jobs:
   build:
@@ -82,6 +83,58 @@ jobs:
           discussion_category_name: Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Publish Docker Image
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Add Docker image publishing to both GitHub Container Registry (GHCR) and Docker Hub in the release workflow.

## Changes

- **Dockerfile**: Multi-stage build (Node.js 24 build stage + nginx serve stage)
- **.dockerignore**: Exclude unnecessary files from Docker build context
- **release.yml**: Add `docker` job that:
  - Logs in to GHCR using `GITHUB_TOKEN`
  - Logs in to Docker Hub using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
  - Uses `docker/metadata-action` for semver-based tagging (version, major.minor, major, latest)
  - Uses `docker/build-push-action` with GitHub Actions cache for efficient builds
  - Adds `packages:write` permission for GHCR push

## Required Secrets

Make sure the following secrets are configured in the repository settings:
- `DOCKERHUB_USERNAME` - Docker Hub username
- `DOCKERHUB_TOKEN` - Docker Hub access token

## Docker Image Tags

When a tag like `1.2.3` is pushed, images will be published with:
- `ghcr.io/databk/rustdesk-console-web:1.2.3`
- `ghcr.io/databk/rustdesk-console-web:1.2`
- `ghcr.io/databk/rustdesk-console-web:1`
- `ghcr.io/databk/rustdesk-console-web:latest`
- `docker.io/<username>/rustdesk-console-web:1.2.3`
- `docker.io/<username>/rustdesk-console-web:1.2`
- `docker.io/<username>/rustdesk-console-web:1`
- `docker.io/<username>/rustdesk-console-web:latest`