### PR TITLE
feat(login): add dark mode toggle button to login page

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -9,6 +9,8 @@ export default {
   'pages.login.forgotPassword': 'Forgot Password?',
   'pages.login.forgotPasswordInfo':
     'Please contact administrator to reset password',
+  'pages.login.switchToDark': 'Switch to dark mode',
+  'pages.login.switchToLight': 'Switch to light mode',
   'pages.devices.list': 'Device List',
   'pages.devices.hostname': 'Hostname',
   'pages.devices.os': 'OS',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -8,6 +8,8 @@ export default {
   'pages.login.rememberMe': '记住我',
   'pages.login.forgotPassword': '忘记密码？',
   'pages.login.forgotPasswordInfo': '请联系管理员重置密码',
+  'pages.login.switchToDark': '切换到深色模式',
+  'pages.login.switchToLight': '切换到亮色模式',
   'pages.devices.list': '设备列表',
   'pages.devices.hostname': '主机名',
   'pages.devices.os': '操作系统',

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -3,29 +3,40 @@ import { LoginForm, ProFormText } from '@ant-design/pro-components';
 import {
   FormattedMessage,
   Helmet,
+  history,
   SelectLang,
   useIntl,
   useModel,
-  history,
 } from '@umijs/max';
 import { Alert, App, Checkbox } from 'antd';
 import { createStyles } from 'antd-style';
 import React, { useState } from 'react';
 import { flushSync } from 'react-dom';
-import { setToken } from '@/utils/auth';
-import { Footer } from '@/components';
+import { Footer, ThemeToggle } from '@/components';
 import { login } from '@/services/rustdesk-console/auth';
+import { setToken } from '@/utils/auth';
 import Settings from '../../../../config/defaultSettings';
 
-const useStyles = createStyles(({ token }) => {
+const useStyles = createStyles(({ token, isDarkMode }) => {
   return {
-    lang: {
+    topActions: {
+      position: 'fixed',
+      right: 16,
+      top: 16,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 4,
+      zIndex: 10,
+    },
+    actionBtn: {
       width: 42,
       height: 42,
       lineHeight: '42px',
-      position: 'fixed',
-      right: 16,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       borderRadius: token.borderRadius,
+      cursor: 'pointer',
       ':hover': {
         backgroundColor: token.colorBgTextHover,
       },
@@ -35,9 +46,11 @@ const useStyles = createStyles(({ token }) => {
       flexDirection: 'column',
       height: '100vh',
       overflow: 'auto',
-      backgroundImage:
-        "url('https://mdn.alipayobjects.com/yuyan_qk0oxh/afts/img/V-_oS6r-i7wAAAAAAAAAAAAAFl94AQBr')",
+      backgroundImage: isDarkMode
+        ? 'none'
+        : "url('https://mdn.alipayobjects.com/yuyan_qk0oxh/afts/img/V-_oS6r-i7wAAAAAAAAAAAAAFl94AQBr')",
       backgroundSize: '100% 100%',
+      backgroundColor: isDarkMode ? token.colorBgContainer : 'transparent',
     },
     loginFormExtra: {
       display: 'flex',
@@ -57,12 +70,17 @@ const useStyles = createStyles(({ token }) => {
   };
 });
 
-const Lang = () => {
+const TopActions = () => {
   const { styles } = useStyles();
 
   return (
-    <div className={styles.lang} data-lang>
-      {SelectLang && <SelectLang />}
+    <div className={styles.topActions}>
+      <span className={styles.actionBtn}>
+        <ThemeToggle />
+      </span>
+      <span className={styles.actionBtn} data-lang>
+        {SelectLang && <SelectLang />}
+      </span>
     </div>
   );
 };
@@ -158,7 +176,7 @@ const Login: React.FC = () => {
           {Settings.title && ` - ${Settings.title}`}
         </title>
       </Helmet>
-      <Lang />
+      <TopActions />
       <div
         style={{
           flex: '1',


### PR DESCRIPTION
## Summary

- Add a dark mode toggle button (ThemeToggle) to the login page, placed alongside the language selector in the top-right corner
- Adapt login page background for dark mode: remove the light background image and use the antd container background color instead
- Add i18n keys (`pages.login.switchToDark` / `pages.login.switchToLight`) for both zh-CN and en-US locales

## Changes

| File | Change |
|------|--------|
| `src/pages/user/login/index.tsx` | Import `ThemeToggle`, replace `Lang` component with `TopActions` (theme toggle + language selector), use `isDarkMode` from `createStyles` to conditionally apply background |
| `src/locales/zh-CN/pages.ts` | Add dark/light mode switching i18n keys |
| `src/locales/en-US/pages.ts` | Add dark/light mode switching i18n keys |

## Test plan

- [ ] Verify the theme toggle button appears in the top-right corner of the login page
- [ ] Click the toggle to switch to dark mode and verify the background adapts (no light background image, dark container background)
- [ ] Click the toggle again to switch back to light mode and verify the original background image is restored
- [ ] Verify the language selector still works correctly alongside the theme toggle
- [ ] Verify the theme setting persists after page reload (localStorage)
- [ ] Verify i18n labels for the toggle tooltip in both zh-CN and en-US