### PR TITLE
feat(devices): implement batch status update for devices

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -53,6 +53,20 @@ export default {
   'pages.devices.batchRemoveFromGroupConfirm':
     'Are you sure to remove selected devices from the group?',
   'pages.devices.selectedDevices': 'Selected {count} device(s)',
+  'pages.devices.batchEnable': 'Batch Enable',
+  'pages.devices.batchDisable': 'Batch Disable',
+  'pages.devices.batchEnableConfirm':
+    'Are you sure to enable selected devices?',
+  'pages.devices.batchDisableConfirm':
+    'Are you sure to disable selected devices?',
+  'pages.devices.batchEnableSuccess': 'Successfully enabled {count} device(s)',
+  'pages.devices.batchEnableFailed': 'Failed to enable devices',
+  'pages.devices.batchEnablePartialFailed':
+    'Successfully enabled {success} device(s), {failed} failed',
+  'pages.devices.batchDisableSuccess': 'Successfully disabled {count} device(s)',
+  'pages.devices.batchDisableFailed': 'Failed to disable devices',
+  'pages.devices.batchDisablePartialFailed':
+    'Successfully disabled {success} device(s), {failed} failed',
   'pages.addressBook.name': 'Name',
   'pages.addressBook.note': 'Note',
   'pages.addressBook.shared': 'Shared Address Books',

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -63,7 +63,8 @@ export default {
   'pages.devices.batchEnableFailed': 'Failed to enable devices',
   'pages.devices.batchEnablePartialFailed':
     'Successfully enabled {success} device(s), {failed} failed',
-  'pages.devices.batchDisableSuccess': 'Successfully disabled {count} device(s)',
+  'pages.devices.batchDisableSuccess':
+    'Successfully disabled {count} device(s)',
   'pages.devices.batchDisableFailed': 'Failed to disable devices',
   'pages.devices.batchDisablePartialFailed':
     'Successfully disabled {success} device(s), {failed} failed',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -48,6 +48,18 @@ export default {
   'pages.devices.batchRemoveFromGroupFailed': '从组中移除设备失败',
   'pages.devices.batchRemoveFromGroupConfirm': '确定要从组中移除选中的设备吗？',
   'pages.devices.selectedDevices': '已选择 {count} 个设备',
+  'pages.devices.batchEnable': '批量启用',
+  'pages.devices.batchDisable': '批量禁用',
+  'pages.devices.batchEnableConfirm': '确定要启用选中的设备吗？',
+  'pages.devices.batchDisableConfirm': '确定要禁用选中的设备吗？',
+  'pages.devices.batchEnableSuccess': '成功启用 {count} 个设备',
+  'pages.devices.batchEnableFailed': '启用设备失败',
+  'pages.devices.batchEnablePartialFailed':
+    '成功启用 {success} 个设备，{failed} 个失败',
+  'pages.devices.batchDisableSuccess': '成功禁用 {count} 个设备',
+  'pages.devices.batchDisableFailed': '禁用设备失败',
+  'pages.devices.batchDisablePartialFailed':
+    '成功禁用 {success} 个设备，{failed} 个失败',
   'pages.addressBook.name': '名称',
   'pages.addressBook.note': '备注',
   'pages.addressBook.shared': '共享地址簿',

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -6,9 +6,8 @@ import {
   SelectOutlined,
 } from '@ant-design/icons';
 import {
+  batchUpdateDeviceStatus,
   deleteDevice,
-  disableDevice,
-  enableDevice,
   getDeviceList,
 } from '@/services/rustdesk-console/device';
 import {
@@ -47,13 +46,25 @@ const DeviceList: React.FC<DeviceListProps> = ({
 
   const handleEnable = async (guid: string) => {
     try {
-      await enableDevice(guid);
-      msgApi.success(
-        intl.formatMessage({
-          id: 'pages.devices.enableSuccess',
-          defaultMessage: 'Device enabled',
-        }),
-      );
+      const result = await batchUpdateDeviceStatus({
+        guids: [guid],
+        status: 'enabled',
+      });
+      if (result.failedCount > 0) {
+        msgApi.warning(
+          intl.formatMessage({
+            id: 'pages.devices.enableFailed',
+            defaultMessage: 'Failed to enable device',
+          }),
+        );
+      } else {
+        msgApi.success(
+          intl.formatMessage({
+            id: 'pages.devices.enableSuccess',
+            defaultMessage: 'Device enabled',
+          }),
+        );
+      }
       actionRef.current?.reload();
     } catch {
       msgApi.error(
@@ -67,13 +78,25 @@ const DeviceList: React.FC<DeviceListProps> = ({
 
   const handleDisable = async (guid: string) => {
     try {
-      await disableDevice(guid);
-      msgApi.success(
-        intl.formatMessage({
-          id: 'pages.devices.disableSuccess',
-          defaultMessage: 'Device disabled',
-        }),
-      );
+      const result = await batchUpdateDeviceStatus({
+        guids: [guid],
+        status: 'disabled',
+      });
+      if (result.failedCount > 0) {
+        msgApi.warning(
+          intl.formatMessage({
+            id: 'pages.devices.disableFailed',
+            defaultMessage: 'Failed to disable device',
+          }),
+        );
+      } else {
+        msgApi.success(
+          intl.formatMessage({
+            id: 'pages.devices.disableSuccess',
+            defaultMessage: 'Device disabled',
+          }),
+        );
+      }
       actionRef.current?.reload();
     } catch {
       msgApi.error(
@@ -129,6 +152,99 @@ const DeviceList: React.FC<DeviceListProps> = ({
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [selectedRows, setSelectedRows] = useState<API.DeviceItem[]>([]);
   const [batchRemoving, setBatchRemoving] = useState(false);
+  const [batchStatusUpdating, setBatchStatusUpdating] = useState(false);
+
+  const handleBatchEnable = async () => {
+    if (selectedRows.length === 0) return;
+    setBatchStatusUpdating(true);
+    try {
+      const guids = selectedRows.map((row) => row.guid);
+      const result = await batchUpdateDeviceStatus({
+        guids,
+        status: 'enabled',
+      });
+      if (result.failedCount > 0) {
+        msgApi.warning(
+          intl.formatMessage(
+            {
+              id: 'pages.devices.batchEnablePartialFailed',
+              defaultMessage:
+                'Successfully enabled {success} device(s), {failed} failed',
+            },
+            { success: result.succeededCount, failed: result.failedCount },
+          ),
+        );
+      } else {
+        msgApi.success(
+          intl.formatMessage(
+            {
+              id: 'pages.devices.batchEnableSuccess',
+              defaultMessage: 'Successfully enabled {count} device(s)',
+            },
+            { count: result.succeededCount },
+          ),
+        );
+      }
+      setSelectedRowKeys([]);
+      setSelectedRows([]);
+      actionRef.current?.reload();
+    } catch {
+      msgApi.error(
+        intl.formatMessage({
+          id: 'pages.devices.batchEnableFailed',
+          defaultMessage: 'Failed to enable devices',
+        }),
+      );
+    } finally {
+      setBatchStatusUpdating(false);
+    }
+  };
+
+  const handleBatchDisable = async () => {
+    if (selectedRows.length === 0) return;
+    setBatchStatusUpdating(true);
+    try {
+      const guids = selectedRows.map((row) => row.guid);
+      const result = await batchUpdateDeviceStatus({
+        guids,
+        status: 'disabled',
+      });
+      if (result.failedCount > 0) {
+        msgApi.warning(
+          intl.formatMessage(
+            {
+              id: 'pages.devices.batchDisablePartialFailed',
+              defaultMessage:
+                'Successfully disabled {success} device(s), {failed} failed',
+            },
+            { success: result.succeededCount, failed: result.failedCount },
+          ),
+        );
+      } else {
+        msgApi.success(
+          intl.formatMessage(
+            {
+              id: 'pages.devices.batchDisableSuccess',
+              defaultMessage: 'Successfully disabled {count} device(s)',
+            },
+            { count: result.succeededCount },
+          ),
+        );
+      }
+      setSelectedRowKeys([]);
+      setSelectedRows([]);
+      actionRef.current?.reload();
+    } catch {
+      msgApi.error(
+        intl.formatMessage({
+          id: 'pages.devices.batchDisableFailed',
+          defaultMessage: 'Failed to disable devices',
+        }),
+      );
+    } finally {
+      setBatchStatusUpdating(false);
+    }
+  };
 
   const handleBatchRemoveFromGroup = async () => {
     if (!deviceGroupGuid || selectedRows.length === 0) return;
@@ -338,55 +454,110 @@ const DeviceList: React.FC<DeviceListProps> = ({
           }
           actionRef={actionRef}
           rowKey="guid"
-          rowSelection={
-            deviceGroupGuid
-              ? {
-                  selectedRowKeys,
-                  onChange: (keys, rows) => {
-                    setSelectedRowKeys(keys);
-                    setSelectedRows(rows);
-                  },
-                }
-              : undefined
-          }
-          tableAlertOptionRender={
-            deviceGroupGuid
-              ? () => (
-                  <Space size={16}>
-                    <Popconfirm
-                      title={
-                        <FormattedMessage
-                          id="pages.devices.batchRemoveFromGroupConfirm"
-                          defaultMessage="Are you sure to remove selected devices from the group?"
-                        />
-                      }
-                      onConfirm={handleBatchRemoveFromGroup}
-                      okText={intl.formatMessage({
-                        id: 'pages.common.confirm',
-                        defaultMessage: 'Yes',
-                      })}
-                      cancelText={intl.formatMessage({
-                        id: 'pages.common.cancel',
-                        defaultMessage: 'No',
-                      })}
+          rowSelection={{
+            selectedRowKeys,
+            onChange: (keys, rows) => {
+              setSelectedRowKeys(keys);
+              setSelectedRows(rows);
+            },
+          }}
+          tableAlertOptionRender={() => (
+            <Space size={16}>
+              {deviceGroupGuid ? (
+                <Popconfirm
+                  title={
+                    <FormattedMessage
+                      id="pages.devices.batchRemoveFromGroupConfirm"
+                      defaultMessage="Are you sure to remove selected devices from the group?"
+                    />
+                  }
+                  onConfirm={handleBatchRemoveFromGroup}
+                  okText={intl.formatMessage({
+                    id: 'pages.common.confirm',
+                    defaultMessage: 'Yes',
+                  })}
+                  cancelText={intl.formatMessage({
+                    id: 'pages.common.cancel',
+                    defaultMessage: 'No',
+                  })}
+                >
+                  <Button
+                    type="link"
+                    danger
+                    icon={<DeleteOutlined />}
+                    loading={batchRemoving}
+                    style={{ padding: 0 }}
+                  >
+                    <FormattedMessage
+                      id="pages.devices.batchRemove"
+                      defaultMessage="Batch Remove"
+                    />
+                  </Button>
+                </Popconfirm>
+              ) : (
+                <>
+                  <Popconfirm
+                    title={
+                      <FormattedMessage
+                        id="pages.devices.batchEnableConfirm"
+                        defaultMessage="Are you sure to enable selected devices?"
+                      />
+                    }
+                    onConfirm={handleBatchEnable}
+                    okText={intl.formatMessage({
+                      id: 'pages.common.confirm',
+                      defaultMessage: 'Yes',
+                    })}
+                    cancelText={intl.formatMessage({
+                      id: 'pages.common.cancel',
+                      defaultMessage: 'No',
+                    })}
+                  >
+                    <Button
+                      type="link"
+                      icon={<PlusCircleOutlined />}
+                      loading={batchStatusUpdating}
+                      style={{ padding: 0 }}
                     >
-                      <Button
-                        type="link"
-                        danger
-                        icon={<DeleteOutlined />}
-                        loading={batchRemoving}
-                        style={{ padding: 0 }}
-                      >
-                        <FormattedMessage
-                          id="pages.devices.batchRemove"
-                          defaultMessage="Batch Remove"
-                        />
-                      </Button>
-                    </Popconfirm>
-                  </Space>
-                )
-              : undefined
-          }
+                      <FormattedMessage
+                        id="pages.devices.batchEnable"
+                        defaultMessage="Batch Enable"
+                      />
+                    </Button>
+                  </Popconfirm>
+                  <Popconfirm
+                    title={
+                      <FormattedMessage
+                        id="pages.devices.batchDisableConfirm"
+                        defaultMessage="Are you sure to disable selected devices?"
+                      />
+                    }
+                    onConfirm={handleBatchDisable}
+                    okText={intl.formatMessage({
+                      id: 'pages.common.confirm',
+                      defaultMessage: 'Yes',
+                    })}
+                    cancelText={intl.formatMessage({
+                      id: 'pages.common.cancel',
+                      defaultMessage: 'No',
+                    })}
+                  >
+                    <Button
+                      type="link"
+                      icon={<MinusCircleOutlined />}
+                      loading={batchStatusUpdating}
+                      style={{ padding: 0 }}
+                    >
+                      <FormattedMessage
+                        id="pages.devices.batchDisable"
+                        defaultMessage="Batch Disable"
+                      />
+                    </Button>
+                  </Popconfirm>
+                </>
+              )}
+            </Space>
+          )}
           request={async (params) => {
             const result = await getDeviceList({
               current: params.current || 1,

--- a/src/services/rustdesk-console/device.ts
+++ b/src/services/rustdesk-console/device.ts
@@ -31,12 +31,20 @@ export async function getDeviceList(
   });
 }
 
-export async function enableDevice(guid: string) {
-  return request(`/api/peers/${guid}/enable`, { method: 'POST' });
-}
-
-export async function disableDevice(guid: string) {
-  return request(`/api/peers/${guid}/disable`, { method: 'POST' });
+export async function batchUpdateDeviceStatus(params: {
+  guids: string[];
+  status: 'enabled' | 'disabled';
+}) {
+  return request<{
+    succeeded: string[];
+    failed: Array<{ guid: string; reason: string }>;
+    total: number;
+    succeededCount: number;
+    failedCount: number;
+  }>('/api/devices/status', {
+    method: 'PATCH',
+    data: params,
+  });
 }
 
 export async function deleteDevice(guid: string) {

--- a/src/services/rustdesk-console/index.ts
+++ b/src/services/rustdesk-console/index.ts
@@ -1,5 +1,5 @@
 export { login, logout, currentUser } from './auth';
-export { getDeviceList, enableDevice, disableDevice, deleteDevice, assignDevice } from './device';
+export { getDeviceList, batchUpdateDeviceStatus, deleteDevice, assignDevice } from './device';
 export {
   getUserList,
   createUser,


### PR DESCRIPTION
## Summary

- Replace single device enable/disable API with batch status update API (`PATCH /api/devices/status`)
- Add batch enable and batch disable functionality to device list
- Support both single and batch operations using the unified batch API
- Add proper error handling for partial failures
- Add i18n support for batch operations

## Changes

### API Changes
- Removed `enableDevice` and `disableDevice` single device APIs
- Added `batchUpdateDeviceStatus` API that supports batch operations

### UI Changes
- Added row selection for device list (both in device group context and normal context)
- Added batch enable and batch disable buttons in the table alert area
- Single device enable/disable now uses the batch API internally

### Error Handling
- Proper handling of partial failures with detailed success/failure counts
- Warning messages for partial failures
- Error messages for complete failures

## Test Plan

1. Test single device enable/disable
2. Test batch enable multiple devices
3. Test batch disable multiple devices
4. Test partial failure scenarios
5. Verify i18n messages in both zh-CN and en-US