### PR TITLE
chore: use conventional-changelog-action to generate changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Determine version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: false
+          skip-git-pull: true
 
       - name: Download build artifact
         uses: actions/download-artifact@v8
@@ -71,11 +81,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: ${{ steps.version.outputs.version }}
-          body: |
-            ## rustdesk-console-web ${{ steps.version.outputs.version }}
-
-            ### Changes
-            See [commit history](https://github.com/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}) for details.
+          body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           files: |


### PR DESCRIPTION
## Summary

Replace the hardcoded release body in the Release workflow with auto-generated changelog using [TriPSs/conventional-changelog-action@v6](https://github.com/TriPSs/conventional-changelog-action).

## Changes

- Add `fetch-depth: 0` to checkout step (required by conventional-changelog-action to access full git history)
- Add `TriPSs/conventional-changelog-action@v6` step to generate changelog from conventional commits
- Use `steps.changelog.outputs.clean_changelog` as the release body instead of a hardcoded template
- Set `output-file: false` to avoid writing changelog to files
- Set `skip-git-pull: true` since we're running in a tagged release workflow

## Test plan

- [ ] Verify the workflow syntax is valid
- [ ] On next tag push, confirm the GitHub Release body contains the auto-generated changelog grouped by commit type (feat, fix, etc.)