### PR TITLE
fix(audit): correct file audit search field to use deviceId

### DIFF
--- a/src/pages/audits/file/index.tsx
+++ b/src/pages/audits/file/index.tsx
@@ -35,7 +35,7 @@ interface IInfo {
 }
 
 interface FileAuditSearchParams extends API.PageParams {
-  peerId?: string;
+  deviceId?: string;
   type?: number;
   createdAt?: [string, string];
 }
@@ -254,7 +254,7 @@ const FileAudit: React.FC = () => {
       title: (
         <FormattedMessage id="pages.audits.remote" defaultMessage="Remote" />
       ),
-      dataIndex: 'peerId',
+      dataIndex: 'deviceId',
       tip: intl.formatMessage({
         id: 'pages.audits.remoteSearchTip',
         defaultMessage: 'Search by remote device ID (fuzzy match)',
@@ -425,8 +425,8 @@ const FileAudit: React.FC = () => {
             pageSize: params.pageSize,
           };
 
-          if (params.peerId) {
-            requestParams.peerId = params.peerId;
+          if (params.deviceId) {
+            requestParams.deviceId = params.deviceId;
           }
 
           if (params.type !== undefined && params.type !== null) {


### PR DESCRIPTION
## Problem

The file audit page search field was incorrectly using `peerId` (local device) when it should use `deviceId` (remote device) for searching remote devices.

According to the API:
- `deviceId` represents the remote device
- `peerId` represents the local device

## Changes

- Changed search field `dataIndex` from `'peerId'` to `'deviceId'`
- Updated `FileAuditSearchParams` interface accordingly
- Fixed request parameter handling to use `deviceId`

## Impact

This fix ensures that when users search by "Remote" device in the file audit page, the search correctly filters by the remote device ID instead of the local device ID.