### PR TITLE
fix(login): handle 400 errors and prevent duplicate OTP submission

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@umijs/max';
 import { Alert, App, Button, Checkbox, Divider, Form, Input, Typography } from 'antd';
 import { createStyles } from 'antd-style';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
@@ -222,20 +222,31 @@ const VerifyStep: React.FC<{
   const { styles } = useStyles();
   const intl = useIntl();
   const [otpValue, setOtpValue] = useState('');
+  const submittingRef = useRef(false);
 
   // Reset OTP when step changes
   useEffect(() => {
     setOtpValue('');
+    submittingRef.current = false;
   }, [resetKey]);
+
+  const handleSubmit = useCallback(
+    (code: string) => {
+      if (submittingRef.current) return;
+      submittingRef.current = true;
+      onSubmit(code);
+    },
+    [onSubmit],
+  );
 
   const handleChange = useCallback(
     (value: string) => {
       setOtpValue(value);
       if (value.length === 6) {
-        onSubmit(value);
+        handleSubmit(value);
       }
     },
-    [onSubmit],
+    [handleSubmit],
   );
 
   return (
@@ -265,7 +276,7 @@ const VerifyStep: React.FC<{
         block
         loading={submitting}
         disabled={otpValue.length < 6}
-        onClick={() => onSubmit(otpValue)}
+        onClick={() => handleSubmit(otpValue)}
       >
         {intl.formatMessage({
           id: 'pages.login.verifyCode.submit',
@@ -369,7 +380,7 @@ const Login: React.FC = () => {
     (error: unknown, defaultMsgId: string, defaultMsg: string) => {
       const err = error as { response?: { status?: number; data?: { error?: string; message?: string } } };
       const status = err?.response?.status;
-      if (status === 401) {
+      if (status === 400 || status === 401) {
         const errorData = err?.response?.data;
         setLoginError(
           errorData?.error ||


### PR DESCRIPTION
## Summary

Code review fixes for PR #108.

## Changes

- **handleLoginError**: Include 400 status code in server error message extraction. Previously only 401 errors displayed server-provided messages; 400 errors (e.g. "验证参数不完整", "双因素认证参数不完整") were silently replaced with generic fallback text.
- **VerifyStep**: Add `useRef` guard to prevent race condition where OTP auto-submit (on 6th digit) and manual button click could both fire `onSubmit` before `setSubmitting(true)` takes effect.

## Test Plan

- [ ] Verify 400 errors from login API display server-provided messages
- [ ] Verify 401 errors still display server-provided messages
- [ ] Verify OTP auto-submit works correctly (single submission)
- [ ] Verify manual submit button still works after typing 6 digits