### PR TITLE
refactor: use user data from login response instead of calling currentUser API

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -383,20 +383,8 @@ const Login: React.FC = () => {
     })();
   }, []);
 
-  const fetchUserInfo = useCallback(async () => {
-    const userInfo = await initialState?.fetchUserInfo?.();
-    if (userInfo) {
-      flushSync(() => {
-        setInitialState((s) => ({
-          ...s,
-          currentUser: userInfo,
-        }));
-      });
-    }
-  }, [initialState, setInitialState]);
-
   const handleLoginSuccess = useCallback(
-    async (token: string) => {
+    async (token: string, user?: API.CurrentUser) => {
       setToken(token, rememberMe);
       message.success(
         intl.formatMessage({
@@ -404,11 +392,18 @@ const Login: React.FC = () => {
           defaultMessage: 'Login successful!',
         }),
       );
-      await fetchUserInfo();
+      if (user) {
+        flushSync(() => {
+          setInitialState((s) => ({
+            ...s,
+            currentUser: user,
+          }));
+        });
+      }
       const urlParams = new URL(window.location.href).searchParams;
       history.push(urlParams.get('redirect') || '/');
     },
-    [rememberMe, intl, message, fetchUserInfo],
+    [rememberMe, intl, message, setInitialState],
   );
 
   const handleLoginError = useCallback(
@@ -453,7 +448,7 @@ const Login: React.FC = () => {
         });
 
         if (msg.type === 'access_token' && msg.access_token) {
-          await handleLoginSuccess(msg.access_token);
+          await handleLoginSuccess(msg.access_token, msg.user);
           return;
         }
 
@@ -526,7 +521,7 @@ const Login: React.FC = () => {
         const msg = await login(params);
 
         if (msg.type === 'access_token' && msg.access_token) {
-          await handleLoginSuccess(msg.access_token);
+          await handleLoginSuccess(msg.access_token, msg.user);
           return;
         }
 


### PR DESCRIPTION
## Summary

Remove the redundant `currentUser` API call after successful login. The login API response already includes a `user` object with the same fields returned by the `currentUser` endpoint.

## Changes

- Modified `handleLoginSuccess` to accept an optional `user` parameter from the login response
- Set `currentUser` in initial state directly from login response data instead of calling `fetchUserInfo()` (which triggers `POST /api/currentUser`)
- Updated both `handleAccountSubmit` and `handleVerifySubmit` to pass `msg.user` to `handleLoginSuccess`
- Removed the intermediate `fetchUserInfo` callback that was only used in the login page

## Benefits

- Eliminates one unnecessary API call after login
- Faster login experience (no waiting for second request)