### PR TITLE
refactor: remove unused REMEMBER_ME_KEY and isRememberMe

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,4 @@
 export const TOKEN_KEY = 'rustdesk_access_token';
-const REMEMBER_ME_KEY = 'rustdesk_remember_me';
 
 export function getToken(): string | null {
   return localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
@@ -8,21 +7,14 @@ export function getToken(): string | null {
 export function setToken(token: string, rememberMe: boolean = false) {
   if (rememberMe) {
     localStorage.setItem(TOKEN_KEY, token);
-    localStorage.setItem(REMEMBER_ME_KEY, 'true');
     sessionStorage.removeItem(TOKEN_KEY);
   } else {
     sessionStorage.setItem(TOKEN_KEY, token);
     localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(REMEMBER_ME_KEY);
   }
 }
 
 export function removeToken() {
   localStorage.removeItem(TOKEN_KEY);
   sessionStorage.removeItem(TOKEN_KEY);
-  localStorage.removeItem(REMEMBER_ME_KEY);
-}
-
-export function isRememberMe(): boolean {
-  return localStorage.getItem(REMEMBER_ME_KEY) === 'true';
 }


### PR DESCRIPTION
## Summary

Remove the unused `REMEMBER_ME_KEY` constant and `isRememberMe()` function from `auth.ts`. Neither is referenced anywhere outside the file.

## Changes

- Removed `REMEMBER_ME_KEY` constant
- Removed `localStorage.setItem(REMEMBER_ME_KEY, ...)` calls in `setToken`
- Removed `localStorage.removeItem(REMEMBER_ME_KEY)` calls in `setToken` and `removeToken`
- Removed `isRememberMe()` function