### PR TITLE
feat: persist remember me checkbox state

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -360,7 +360,7 @@ const Login: React.FC = () => {
     null,
   );
   const [loginError, setLoginError] = useState<string>('');
-  const [rememberMe, setRememberMe] = useState(false);
+  const [rememberMe, setRememberMe] = useState(() => localStorage.getItem('rememberMe') === '1');
   const [submitting, setSubmitting] = useState(false);
   const [oidcOptions, setOidcOptions] = useState<API.OidcLoginInfo[]>([]);
   const { initialState, setInitialState } = useModel('@@initialState');
@@ -645,6 +645,11 @@ const Login: React.FC = () => {
           onValuesChange={(values) => {
             if (values.rememberMe !== undefined) {
               setRememberMe(values.rememberMe);
+              if (values.rememberMe) {
+                localStorage.setItem('rememberMe', '1');
+              } else {
+                localStorage.removeItem('rememberMe');
+              }
             }
           }}
           onFinish={async (values) => {

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -360,7 +360,9 @@ const Login: React.FC = () => {
     null,
   );
   const [loginError, setLoginError] = useState<string>('');
-  const [rememberMe, setRememberMe] = useState(() => localStorage.getItem('rememberMe') === '1');
+  const [rememberMe, setRememberMe] = useState(
+    () => localStorage.getItem('rememberMe') === '1',
+  );
   const [submitting, setSubmitting] = useState(false);
   const [oidcOptions, setOidcOptions] = useState<API.OidcLoginInfo[]>([]);
   const { initialState, setInitialState } = useModel('@@initialState');


### PR DESCRIPTION
## Summary

Persist the "Remember Me" checkbox selection in localStorage so that the user's preference is preserved across page reloads and browser sessions.

## Changes

- Read the initial `rememberMe` state from localStorage (`rememberMe` key) instead of hardcoding `false`
- Save/remove the `rememberMe` value to/from localStorage when the checkbox state changes

## Testing

- Verify that checking "Remember Me" persists the checkbox state after page reload
- Verify that unchecking "Remember Me" clears the stored preference