### PR TITLE
fix(audit): update disconnect API to POST /devices/:uuid/disconnect

### DIFF
--- a/src/pages/audits/conn/index.tsx
+++ b/src/pages/audits/conn/index.tsx
@@ -143,12 +143,19 @@ const ConnectionAudit: React.FC = () => {
   const [disconnectModalOpen, setDisconnectModalOpen] = useState(false);
   const [disconnectConfirmLoading, setDisconnectConfirmLoading] =
     useState(false);
-  const [currentDisconnectId, setCurrentDisconnectId] = useState<string>('');
+  const [disconnectTarget, setDisconnectTarget] = useState<{
+    uuid: string;
+    connId: number;
+  }>();
 
   const handleDisconnect = async () => {
+    if (!disconnectTarget) return;
     setDisconnectConfirmLoading(true);
     try {
-      const res = await disconnectConnection(currentDisconnectId);
+      const res = await disconnectConnection(
+        disconnectTarget.uuid,
+        [disconnectTarget.connId],
+      );
       if (res.succ !== false) {
         msgApi.success(
           intl.formatMessage({
@@ -567,7 +574,10 @@ const ConnectionAudit: React.FC = () => {
             type="default"
             danger
             onClick={() => {
-              setCurrentDisconnectId(record.connId || String(record.id));
+              setDisconnectTarget({
+                uuid: record.deviceUuid || '',
+                connId: Number(record.connId || record.id),
+              });
               setDisconnectModalOpen(true);
             }}
           >

--- a/src/pages/audits/conn/index.tsx
+++ b/src/pages/audits/conn/index.tsx
@@ -152,10 +152,9 @@ const ConnectionAudit: React.FC = () => {
     if (!disconnectTarget) return;
     setDisconnectConfirmLoading(true);
     try {
-      const res = await disconnectConnection(
-        disconnectTarget.uuid,
-        [disconnectTarget.connId],
-      );
+      const res = await disconnectConnection(disconnectTarget.uuid, [
+        disconnectTarget.connId,
+      ]);
       if (res.succ !== false) {
         msgApi.success(
           intl.formatMessage({

--- a/src/services/rustdesk-console/audit.ts
+++ b/src/services/rustdesk-console/audit.ts
@@ -79,12 +79,13 @@ export async function updateConnectionAudit(
 }
 
 export async function disconnectConnection(
-  connId: string,
+  uuid: string,
+  connIds: number[],
   options?: { [key: string]: any },
 ) {
-  return request<API.ResponseResult>('/api/audits/conn/disconnect', {
+  return request<API.ResponseResult>(`/api/devices/${uuid}/disconnect`, {
     method: 'POST',
-    data: { connId },
+    data: { connIds },
     ...(options || {}),
   });
 }


### PR DESCRIPTION
## Summary

Update the disconnect connection API to match the new backend interface:

- **Old**: `POST /api/audits/conn/disconnect` with body `{ connId: string }`
- **New**: `POST /api/devices/:uuid/disconnect` with body `{ connIds: number[] }`

The `uuid` is the `deviceUuid` field from the connection audit record, and `connIds` is an array of connection IDs.

## Changes

- `src/services/rustdesk-console/audit.ts`: Change `disconnectConnection` to accept `uuid` (string) and `connIds` (number[]) parameters, use `uuid` in URL path
- `src/pages/audits/conn/index.tsx`: Replace `currentDisconnectId` state with `disconnectTarget` object `{ uuid, connId }`, pass `deviceUuid` and `connId` from audit record

## Test Plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Biome lint passes
- [ ] Manual verification of disconnect functionality