### PR TITLE
feat(login): implement OIDC login with GitHub, GitLab and Google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rustdesk-console-web",
       "version": "1.0.0",
       "hasInstallScript": true,
+      "license": "AGPL-3.0",
       "dependencies": {
         "@ant-design/icons": "^6.2.3",
         "@ant-design/plots": "^2.6.0",
@@ -15,6 +16,7 @@
         "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "antd": "^5.25.4",
         "antd-style": "^3.7.0",
+        "bowser": "^2.11.0",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.13",
         "numeral": "^2.0.6",
@@ -18533,6 +18535,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmmirror.com/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "antd": "^5.25.4",
     "antd-style": "^3.7.0",
+    "bowser": "^2.11.0",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
     "numeral": "^2.0.6",

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -23,7 +23,7 @@ export default {
   'pages.login.verifyCode.invalid': 'Invalid verification code',
   'pages.login.oidc.divider': 'Or continue with',
   'pages.login.oidc.continueWith': 'Continue with {provider}',
-  'pages.login.oidc.comingSoon': 'Third-party login is coming soon',
+  'pages.login.oidc.authFailed': 'OIDC login failed',
   'pages.devices.list': 'Device List',
   'pages.devices.os': 'OS',
   'pages.devices.status': 'Status',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -19,7 +19,7 @@ export default {
   'pages.login.verifyCode.invalid': '验证码无效',
   'pages.login.oidc.divider': '或使用以下方式登录',
   'pages.login.oidc.continueWith': '使用 {provider} 继续',
-  'pages.login.oidc.comingSoon': '第三方登录即将上线',
+  'pages.login.oidc.authFailed': 'OIDC登录失败',
   'pages.devices.list': '设备列表',
   'pages.devices.os': '操作系统',
   'pages.devices.status': '状态',

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -5,6 +5,8 @@ import {
   SafetyCertificateOutlined,
   ArrowLeftOutlined,
   GithubOutlined,
+  GoogleOutlined,
+  GitlabOutlined,
 } from '@ant-design/icons';
 import { LoginForm, ProFormText } from '@ant-design/pro-components';
 import {
@@ -36,7 +38,7 @@ import React, {
 import { flushSync } from 'react-dom';
 import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
-import { login, getLoginOptions } from '@/services/rustdesk-console/auth';
+import { login, getLoginOptions, oidcAuth } from '@/services/rustdesk-console/auth';
 import Settings from '../../../../config/defaultSettings';
 
 // --- Auth step types ---
@@ -71,6 +73,8 @@ function getDeviceInfo(): API.DeviceInfo {
 // --- OIDC icon mapping ---
 const OIDC_ICONS: Record<string, React.ReactNode> = {
   github: <GithubOutlined style={{ fontSize: 20 }} />,
+  gitlab: <GitlabOutlined style={{ fontSize: 20 }} />,
+  google: <GoogleOutlined style={{ fontSize: 20 }} />,
 };
 
 const OIDC_LABELS: Record<string, string> = {
@@ -180,8 +184,52 @@ const OidcLogin: React.FC<{
   const { styles } = useStyles();
   const intl = useIntl();
   const { message } = App.useApp();
+  const [oidcLoading, setOidcLoading] = useState<string>('');
 
   if (options.length === 0) return null;
+
+  const handleOidcLogin = async (provider: string) => {
+    if (loading || oidcLoading) return;
+    
+    setOidcLoading(provider);
+    try {
+      const deviceInfo = getDeviceInfo();
+      const redirectUrl = `${window.location.origin}/#/dashboard`;
+      
+      const response = await oidcAuth({
+        op: provider,
+        deviceInfo,
+        redirectUrl,
+      });
+
+      if (response.url) {
+        window.location.href = response.url;
+      } else {
+        message.error(
+          intl.formatMessage({
+            id: 'pages.login.oidc.authFailed',
+            defaultMessage: 'Failed to get authorization URL',
+          }),
+        );
+      }
+    } catch (error: unknown) {
+      const err = error as {
+        response?: {
+          status?: number;
+          data?: { error?: string; message?: string };
+        };
+      };
+      const errorMsg = err?.response?.data?.error ||
+        err?.response?.data?.message ||
+        intl.formatMessage({
+          id: 'pages.login.oidc.authFailed',
+          defaultMessage: 'Failed to initiate OIDC login',
+        });
+      message.error(errorMsg);
+    } finally {
+      setOidcLoading('');
+    }
+  };
 
   return (
     <div className={styles.oidcSection}>
@@ -198,15 +246,9 @@ const OidcLogin: React.FC<{
           <Button
             key={item.name}
             className={styles.oidcButton}
-            disabled={loading}
-            onClick={() => {
-              message.info(
-                intl.formatMessage({
-                  id: 'pages.login.oidc.comingSoon',
-                  defaultMessage: 'Third-party login is coming soon',
-                }),
-              );
-            }}
+            disabled={loading || oidcLoading !== ''}
+            loading={oidcLoading === item.name}
+            onClick={() => handleOidcLogin(item.name)}
           >
             {icon}
             {intl.formatMessage(
@@ -365,7 +407,7 @@ const Login: React.FC = () => {
   );
   const [submitting, setSubmitting] = useState(false);
   const [oidcOptions, setOidcOptions] = useState<API.OidcLoginInfo[]>([]);
-  const { initialState, setInitialState } = useModel('@@initialState');
+  const { setInitialState } = useModel('@@initialState');
   const { styles } = useStyles();
   const { message } = App.useApp();
   const intl = useIntl();

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -36,6 +36,7 @@ import React, {
   useState,
 } from 'react';
 import { flushSync } from 'react-dom';
+import Bowser from 'bowser';
 import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
 import { login, getLoginOptions, oidcAuth } from '@/services/rustdesk-console/auth';
@@ -53,21 +54,12 @@ type VerifySession = {
 
 // --- Device info ---
 function getDeviceInfo(): API.DeviceInfo {
-  const ua = navigator.userAgent;
-  let os = 'Unknown';
-  if (ua.includes('Win')) os = 'Windows';
-  else if (ua.includes('Mac')) os = 'macOS';
-  else if (ua.includes('Linux')) os = 'Linux';
-  else if (ua.includes('Android')) os = 'Android';
-  else if (ua.includes('iPhone') || ua.includes('iPad')) os = 'iOS';
-
-  let browserName = 'Unknown';
-  if (ua.includes('Firefox')) browserName = 'Firefox';
-  else if (ua.includes('Edg')) browserName = 'Edge';
-  else if (ua.includes('Chrome')) browserName = 'Chrome';
-  else if (ua.includes('Safari')) browserName = 'Safari';
-
-  return { os, type: 'browser', name: browserName };
+  const browser = Bowser.getParser(window.navigator.userAgent);
+  return {
+    os: browser.getOSName(true),
+    type: 'browser',
+    name: `${browser.getBrowserName()} - ${browser.getBrowserVersion()}`,
+  };
 }
 
 // --- OIDC icon mapping ---

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -186,12 +186,12 @@ const OidcLogin: React.FC<{
     setOidcLoading(provider);
     try {
       const deviceInfo = getDeviceInfo();
-      const redirectUrl = `${window.location.origin}/#/dashboard`;
+      const callbackUrl = `${window.location.origin}/#/dashboard`;
       
       const response = await oidcAuth({
         op: provider,
         deviceInfo,
-        redirectUrl,
+        callbackUrl,
       });
 
       if (response.url) {

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -39,7 +39,11 @@ import { flushSync } from 'react-dom';
 import Bowser from 'bowser';
 import { setToken } from '@/utils/auth';
 import { Footer } from '@/components';
-import { login, getLoginOptions, oidcAuth } from '@/services/rustdesk-console/auth';
+import {
+  login,
+  getLoginOptions,
+  oidcAuth,
+} from '@/services/rustdesk-console/auth';
 import Settings from '../../../../config/defaultSettings';
 
 // --- Auth step types ---
@@ -182,12 +186,12 @@ const OidcLogin: React.FC<{
 
   const handleOidcLogin = async (provider: string) => {
     if (loading || oidcLoading) return;
-    
+
     setOidcLoading(provider);
     try {
       const deviceInfo = getDeviceInfo();
       const callbackUrl = `${window.location.origin}/#/dashboard`;
-      
+
       const response = await oidcAuth({
         op: provider,
         deviceInfo,
@@ -211,7 +215,8 @@ const OidcLogin: React.FC<{
           data?: { error?: string; message?: string };
         };
       };
-      const errorMsg = err?.response?.data?.error ||
+      const errorMsg =
+        err?.response?.data?.error ||
         err?.response?.data?.message ||
         intl.formatMessage({
           id: 'pages.login.oidc.authFailed',

--- a/src/services/rustdesk-console/auth.ts
+++ b/src/services/rustdesk-console/auth.ts
@@ -25,4 +25,12 @@ export async function getLoginOptions() {
   });
 }
 
+export async function oidcAuth(body: API.OidcAuthParams) {
+  return request<API.OidcAuthResponse>('/api/oidc/auth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    data: body,
+  });
+}
+
 export const getCurrentUser = currentUser;

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -44,6 +44,19 @@ declare namespace API {
     icon?: string;
   };
 
+  type OidcAuthParams = {
+    op: string;
+    id?: string;
+    uuid?: string;
+    deviceInfo?: DeviceInfo;
+    redirectUrl?: string;
+  };
+
+  type OidcAuthResponse = {
+    code?: string;
+    url?: string;
+  };
+
   type PageParams = {
     current?: number;
     pageSize?: number;

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -46,10 +46,10 @@ declare namespace API {
 
   type OidcAuthParams = {
     op: string;
+    deviceInfo: DeviceInfo;
+    redirectUrl: string;
     id?: string;
     uuid?: string;
-    deviceInfo?: DeviceInfo;
-    redirectUrl?: string;
   };
 
   type OidcAuthResponse = {

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -47,7 +47,7 @@ declare namespace API {
   type OidcAuthParams = {
     op: string;
     deviceInfo: DeviceInfo;
-    redirectUrl: string;
+    callbackUrl: string;
     id?: string;
     uuid?: string;
   };


### PR DESCRIPTION
## Summary

This PR implements complete OIDC (OpenID Connect) login functionality for the RustDesk Console Web application.

## Changes

### API Layer
- Added  function in  to call  endpoint
- Added type definitions:  and 

### Login Page
- Implemented OIDC login button click logic with redirect to provider
- Added support for GitHub, GitLab, and Google OIDC providers
- Added  and  icons from Ant Design
- Implemented loading state and error handling

### Internationalization
- Updated OIDC-related i18n texts for error messages (zh-CN and en-US)

### Code Quality
- Fixed lint warnings: use template strings and remove unused variables
- TypeScript type checking passed

## Implementation Flow

1. User clicks OIDC button (GitHub/GitLab/Google)
2. Call 
3. Backend returns authorization URL
4. Frontend redirects to OIDC provider authorization page
5. User authenticates on OIDC provider page
6. OIDC provider callback to backend callback endpoint
7. Backend sets JWT token and redirects to frontend dashboard
8. Login completed

## Testing

- TypeScript type checking passed
- Lint checking passed
- Ready for integration testing

## Related

Based on the example OIDC implementation in 