### PR TITLE
fix: skip global error handler for login API

### DIFF
--- a/src/services/rustdesk-console/auth.ts
+++ b/src/services/rustdesk-console/auth.ts
@@ -5,6 +5,7 @@ export async function login(body: API.LoginParams) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     data: body,
+    skipErrorHandler: true,
   });
 }
 


### PR DESCRIPTION
## Problem

When login fails (wrong username/password), the backend returns a 401 status code. The global error handler in `requestErrorConfig.ts` intercepts all 401 responses and shows "Login expired, please login again" message, which is incorrect and confusing for users who are trying to log in.

## Solution

Add `skipErrorHandler: true` to the login API request configuration. This allows the login page to handle authentication errors with appropriate error messages (e.g., "Invalid username or password") instead of being intercepted by the global error handler.

## Changes

- Modified `src/services/rustdesk-console/auth.ts`: Added `skipErrorHandler: true` to the login request options

## Testing

1. Try to login with an invalid username/password
2. Verify that the error message from the server is displayed correctly instead of "Login expired, please login again"