### PR TITLE
fix: skip global error handler for SMTP config API

### DIFF
--- a/src/services/rustdesk-console/smtp.ts
+++ b/src/services/rustdesk-console/smtp.ts
@@ -6,6 +6,7 @@ import { request } from '@umijs/max';
 export async function getSMTPConfig() {
   return request<API.SMTPConfig>('/api/settings/smtp', {
     method: 'GET',
+    skipErrorHandler: true,
   });
 }
 


### PR DESCRIPTION
## Problem

When accessing the SMTP settings page without an existing SMTP configuration, the API returns a 404 status code. The global error handler intercepts this and shows "Response status: 404" at the top of the page, which is confusing because 404 here means "no config exists yet" - a normal state, not an error.

## Solution

Add `skipErrorHandler: true` to the `getSMTPConfig` API request. This allows the SMTP settings page to handle 404 gracefully in its own error handling logic (which already correctly treats 404 as "config not exists" state).

## Changes

- Modified `src/services/rustdesk-console/smtp.ts`: Added `skipErrorHandler: true` to `getSMTPConfig` request options

## Testing

1. Access SMTP settings page when no SMTP config exists
2. Verify that no "Response status: 404" error message appears
3. The page should show empty form fields ready for new configuration