### PR TITLE
feat(devices): update delete API and add edit device feature

### DIFF
--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -81,6 +81,12 @@ export default {
   'pages.devices.batchDisableFailed': 'Failed to disable devices',
   'pages.devices.batchDisablePartialFailed':
     'Successfully disabled {success} device(s), {failed} failed',
+  'pages.devices.edit': 'Edit Device',
+  'pages.devices.updateSuccess': 'Device updated',
+  'pages.devices.updateFailed': 'Failed to update device',
+  'pages.devices.enterUserName': 'Enter username to associate',
+  'pages.devices.enterDeviceGroupName': 'Enter device group name to associate',
+  'pages.devices.enterStrategyName': 'Enter strategy name to associate',
   'pages.addressBook.name': 'Name',
   'pages.addressBook.note': 'Note',
   'pages.addressBook.shared': 'Shared Address Books',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -70,6 +70,12 @@ export default {
   'pages.devices.batchDisableFailed': '禁用设备失败',
   'pages.devices.batchDisablePartialFailed':
     '成功禁用 {success} 个设备，{failed} 个失败',
+  'pages.devices.edit': '编辑设备',
+  'pages.devices.updateSuccess': '设备已更新',
+  'pages.devices.updateFailed': '更新设备失败',
+  'pages.devices.enterUserName': '输入关联用户名',
+  'pages.devices.enterDeviceGroupName': '输入关联设备组名',
+  'pages.devices.enterStrategyName': '输入关联策略名',
   'pages.addressBook.name': '名称',
   'pages.addressBook.note': '备注',
   'pages.addressBook.shared': '共享地址簿',

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -9,6 +9,7 @@ import {
   batchUpdateDeviceStatus,
   deleteDevice,
   getDeviceList,
+  updateDevice,
 } from '@/services/rustdesk-console/device';
 import {
   addDeviceToGroup,
@@ -17,7 +18,7 @@ import {
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { App, Button, Divider, Modal, Popconfirm, Space } from 'antd';
+import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
 import React, { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Settings from '../../../../config/defaultSettings';
@@ -43,6 +44,11 @@ const DeviceList: React.FC<DeviceListProps> = ({
     useState(false);
   const [selectedDeviceKeys, setSelectedDeviceKeys] = useState<React.Key[]>([]);
   const [importing, setImporting] = useState(false);
+
+  const [editModalVisible, setEditModalVisible] = useState(false);
+  const [editingRecord, setEditingRecord] =
+    useState<API.DeviceItem | null>(null);
+  const [editForm] = Form.useForm();
 
   const handleEnable = async (guid: string) => {
     try {
@@ -123,6 +129,50 @@ const DeviceList: React.FC<DeviceListProps> = ({
         intl.formatMessage({
           id: 'pages.devices.deleteFailed',
           defaultMessage: 'Failed to delete device',
+        }),
+      );
+    }
+  };
+
+  const handleEdit = async (values: Record<string, string | null>) => {
+    if (!editingRecord) return;
+    try {
+      const data: API.UpdateDeviceParams = {};
+      const original: Record<string, string | undefined> = {
+        userName: editingRecord.user_name,
+        deviceGroupName: editingRecord.device_group_name,
+        strategyName: editingRecord.strategy_name,
+        note: editingRecord.note,
+      };
+      const fieldMap: Record<string, keyof API.UpdateDeviceParams> = {
+        userName: 'userName',
+        deviceGroupName: 'deviceGroupName',
+        strategyName: 'strategyName',
+        note: 'note',
+      };
+      for (const [formKey, paramKey] of Object.entries(fieldMap)) {
+        const originalValue = original[formKey] || '';
+        const newValue = values[formKey] ?? '';
+        if (newValue !== originalValue) {
+          data[paramKey] = newValue === '' ? null : newValue;
+        }
+      }
+      await updateDevice(editingRecord.guid, data);
+      msgApi.success(
+        intl.formatMessage({
+          id: 'pages.devices.updateSuccess',
+          defaultMessage: 'Device updated',
+        }),
+      );
+      setEditModalVisible(false);
+      setEditingRecord(null);
+      editForm.resetFields();
+      actionRef.current?.reload();
+    } catch {
+      msgApi.error(
+        intl.formatMessage({
+          id: 'pages.devices.updateFailed',
+          defaultMessage: 'Failed to update device',
         }),
       );
     }
@@ -361,7 +411,22 @@ const DeviceList: React.FC<DeviceListProps> = ({
       // Normal device list (not in device group context)
       return (
         <Space size={0} split={<Divider type="vertical" />}>
-          <Button key="edit" type="link" size="small" icon={<EditOutlined />}>
+          <Button
+            key="edit"
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => {
+              setEditingRecord(record);
+              editForm.setFieldsValue({
+                userName: record.user_name || '',
+                deviceGroupName: record.device_group_name || '',
+                strategyName: record.strategy_name || '',
+                note: record.note || '',
+              });
+              setEditModalVisible(true);
+            }}
+          >
             <FormattedMessage id="pages.common.edit" defaultMessage="Edit" />
           </Button>
           {isDisabled ? (
@@ -642,6 +707,84 @@ const DeviceList: React.FC<DeviceListProps> = ({
             />
           </Modal>
         )}
+
+        <Modal
+          title={
+            <FormattedMessage
+              id="pages.devices.edit"
+              defaultMessage="Edit Device"
+            />
+          }
+          open={editModalVisible}
+          onCancel={() => {
+            setEditModalVisible(false);
+            setEditingRecord(null);
+            editForm.resetFields();
+          }}
+          onOk={() => editForm.submit()}
+        >
+          <Form form={editForm} onFinish={handleEdit} layout="vertical">
+            <Form.Item
+              name="userName"
+              label={
+                <FormattedMessage
+                  id="pages.devices.user"
+                  defaultMessage="User"
+                />
+              }
+            >
+              <Input
+                placeholder={intl.formatMessage({
+                  id: 'pages.devices.enterUserName',
+                  defaultMessage: 'Enter username to associate',
+                })}
+              />
+            </Form.Item>
+            <Form.Item
+              name="deviceGroupName"
+              label={
+                <FormattedMessage
+                  id="pages.devices.deviceGroup"
+                  defaultMessage="Group"
+                />
+              }
+            >
+              <Input
+                placeholder={intl.formatMessage({
+                  id: 'pages.devices.enterDeviceGroupName',
+                  defaultMessage: 'Enter device group name to associate',
+                })}
+              />
+            </Form.Item>
+            <Form.Item
+              name="strategyName"
+              label={
+                <FormattedMessage
+                  id="pages.devices.strategy"
+                  defaultMessage="Strategy"
+                />
+              }
+            >
+              <Input
+                placeholder={intl.formatMessage({
+                  id: 'pages.devices.enterStrategyName',
+                  defaultMessage: 'Enter strategy name to associate',
+                })}
+              />
+            </Form.Item>
+            <Form.Item
+              name="note"
+              label={
+                <FormattedMessage
+                  id="pages.devices.note"
+                  defaultMessage="Note"
+                />
+              }
+            >
+              <Input.TextArea />
+            </Form.Item>
+          </Form>
+        </Modal>
       </PageContainer>
     </>
   );

--- a/src/pages/devices/list/index.tsx
+++ b/src/pages/devices/list/index.tsx
@@ -18,7 +18,16 @@ import {
 import type { ActionType, ProColumns } from '@ant-design/pro-components';
 import { PageContainer, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { App, Button, Divider, Form, Input, Modal, Popconfirm, Space } from 'antd';
+import {
+  App,
+  Button,
+  Divider,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+} from 'antd';
 import React, { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Settings from '../../../../config/defaultSettings';
@@ -46,8 +55,9 @@ const DeviceList: React.FC<DeviceListProps> = ({
   const [importing, setImporting] = useState(false);
 
   const [editModalVisible, setEditModalVisible] = useState(false);
-  const [editingRecord, setEditingRecord] =
-    useState<API.DeviceItem | null>(null);
+  const [editingRecord, setEditingRecord] = useState<API.DeviceItem | null>(
+    null,
+  );
   const [editForm] = Form.useForm();
 
   const handleEnable = async (guid: string) => {

--- a/src/services/rustdesk-console/device.ts
+++ b/src/services/rustdesk-console/device.ts
@@ -48,7 +48,17 @@ export async function batchUpdateDeviceStatus(params: {
 }
 
 export async function deleteDevice(guid: string) {
-  return request(`/api/peers/${guid}`, { method: 'DELETE' });
+  return request(`/api/devices/${guid}`, { method: 'DELETE' });
+}
+
+export async function updateDevice(
+  guid: string,
+  data: API.UpdateDeviceParams,
+) {
+  return request(`/api/devices/${guid}`, {
+    method: 'PATCH',
+    data,
+  });
 }
 
 export async function assignDevice(guid: string, data: Record<string, any>) {

--- a/src/services/rustdesk-console/index.ts
+++ b/src/services/rustdesk-console/index.ts
@@ -7,7 +7,7 @@ export {
   verify2FA,
   disable2FA,
 } from './account';
-export { getDeviceList, batchUpdateDeviceStatus, deleteDevice, assignDevice } from './device';
+export { getDeviceList, batchUpdateDeviceStatus, deleteDevice, updateDevice, assignDevice } from './device';
 export {
   getAdminUserList,
   createUser,

--- a/src/services/rustdesk-console/typings.d.ts
+++ b/src/services/rustdesk-console/typings.d.ts
@@ -200,6 +200,13 @@ declare namespace API {
     [key: string]: any;
   };
 
+  type UpdateDeviceParams = {
+    userName?: string | null;
+    deviceGroupName?: string | null;
+    strategyName?: string | null;
+    note?: string | null;
+  };
+
   type DeviceGroupItem = {
     guid: string;
     name: string;


### PR DESCRIPTION
## Changes

- **Delete API update**: Changed delete device API endpoint from `DELETE /api/peers/:guid` to `DELETE /api/devices/:guid`
- **Edit device feature**: Added `PATCH /api/devices/:guid` API for editing device with the following fields:
  - `userName` - associate by username
  - `deviceGroupName` - associate by group name
  - `strategyName` - associate by strategy name
  - `note` - set note
- **Edit modal**: Added edit device modal on the device list page with form fields
- **Type definition**: Added `UpdateDeviceParams` type
- **i18n**: Added Chinese and English translations for edit device feature

### API Behavior
- Send `null` to clear a field's association
- Omit a field to leave it unchanged
- Only changed fields are included in the request payload