### PR TITLE
fix: hide SettingDrawer in production environment

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -154,18 +154,20 @@ export const layout: RunTimeLayoutConfig = ({
         <>
           <AuthSync />
           {children}
-          <SettingDrawer
-            disableUrlParams
-            enableDarkTheme
-            settings={initialState?.settings}
-            onSettingChange={(settings) => {
-              storeThemeSettings(settings);
-              setInitialState((preInitialState) => ({
-                ...preInitialState,
-                settings,
-              }));
-            }}
-          />
+          {isDev && (
+            <SettingDrawer
+              disableUrlParams
+              enableDarkTheme
+              settings={initialState?.settings}
+              onSettingChange={(settings) => {
+                storeThemeSettings(settings);
+                setInitialState((preInitialState) => ({
+                  ...preInitialState,
+                  settings,
+                }));
+              }}
+            />
+          )}
         </>
       );
     },


### PR DESCRIPTION
## Problem

The `SettingDrawer` component (right-side configuration panel) was unconditionally rendered in all environments. Although its hint text claims "配置栏只在开发环境用于预览，生产环境不会展现", the component itself had no environment check, causing it to appear in production Docker builds as well.

## Solution

Wrap the `SettingDrawer` component with the existing `isDev` condition (`process.env.NODE_ENV === 'development' || process.env.CI`) in `src/app.tsx`, so it only renders in development mode.

## Changes

- `src/app.tsx`: Conditionally render `SettingDrawer` only when `isDev` is true

## Testing

- TypeScript type check passes (`tsc --noEmit`)
- The `isDev` variable was already defined and used elsewhere in the same file (e.g., for the `links` property), so this change is consistent with existing patterns