### PR TITLE
fix: remove login watermark

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -129,9 +129,6 @@ export const layout: RunTimeLayoutConfig = ({
         return <AvatarDropdown>{avatarChildren}</AvatarDropdown>;
       },
     },
-    waterMarkProps: {
-      content: initialState?.currentUser?.name,
-    },
     footerRender: () => <Footer />,
     onPageChange: () => {
       const { location } = history;


### PR DESCRIPTION
This PR removes the default Ant Design Pro page watermark that displayed the current user's name across the console UI.

The change addresses the concern discussed in databk/rustdesk-console#136