### PR TITLE
feat: display user avatar in header navigation bar

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components';
 import { currentUser as queryCurrentUser } from '@/services/rustdesk-console/auth';
 import { getToken, TOKEN_KEY } from '@/utils/auth';
+import { getAvatarUrl } from '@/utils/avatar';
 import defaultSettings from '../config/defaultSettings';
 import { errorConfig } from './requestErrorConfig';
 import '@ant-design/v5-patch-for-react-19';
@@ -123,7 +124,7 @@ export const layout: RunTimeLayoutConfig = ({
       <SelectLang key="SelectLang" />,
     ],
     avatarProps: {
-      src: undefined,
+      src: getAvatarUrl(initialState?.currentUser?.avatar),
       title: <AvatarName />,
       render: (_, avatarChildren) => {
         return <AvatarDropdown>{avatarChildren}</AvatarDropdown>;

--- a/src/pages/account/center/components/AvatarSetting.tsx
+++ b/src/pages/account/center/components/AvatarSetting.tsx
@@ -16,6 +16,7 @@ import {
 } from 'antd';
 import React, { useState } from 'react';
 import { uploadAvatar, deleteAvatar } from '@/services/rustdesk-console';
+import { getAvatarUrl } from '@/utils/avatar';
 
 const { Text } = Typography;
 
@@ -26,7 +27,7 @@ const AvatarSetting: React.FC = () => {
   const [uploading, setUploading] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  const avatarUrl = currentUser?.avatar || undefined;
+  const avatarUrl = getAvatarUrl(currentUser?.avatar);
 
   const handleUpload = async (file: File) => {
     if (file.size > 2 * 1024 * 1024) {

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,19 @@
+/**
+ * Get the full avatar URL from the avatar field returned by the backend.
+ * - If avatar is falsy, returns undefined (fallback to default icon).
+ * - If avatar starts with http:// or https://, returns as-is (full URL).
+ * - If avatar starts with /, returns as-is (relative path, resolved by proxy/nginx).
+ * - Otherwise, prepends / to make it a valid relative path.
+ */
+export function getAvatarUrl(avatar?: string): string | undefined {
+  if (!avatar) {
+    return undefined;
+  }
+  if (avatar.startsWith('http://') || avatar.startsWith('https://')) {
+    return avatar;
+  }
+  if (avatar.startsWith('/')) {
+    return avatar;
+  }
+  return `/${avatar}`;
+}


### PR DESCRIPTION
## Summary

- Add `getAvatarUrl` utility function to handle both relative and absolute avatar URLs
- Fix `avatarProps.src` in ProLayout to use `currentUser.avatar` instead of hardcoded `undefined`
- Update `AvatarSetting` component to use the same utility for consistency

## Changes

| File | Change |
|------|--------|
| `src/utils/avatar.ts` | New utility: handles full URLs (http/https), relative paths (starting with /), and bare paths |
| `src/app.tsx` | Use `getAvatarUrl(initialState?.currentUser?.avatar)` for `avatarProps.src` |
| `src/pages/account/center/components/AvatarSetting.tsx` | Use `getAvatarUrl` instead of inline `currentUser?.avatar \|\| undefined` |

## Test Plan

- [ ] Verify header avatar shows user's uploaded avatar image
- [ ] Verify header avatar falls back to default icon when no avatar is set
- [ ] Verify avatar upload/delete in Account Center still works correctly
- [ ] Test with both relative paths and full URLs returned by the backend