### PR TITLE
feat: update release workflow to auto-generate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,25 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '[0-9]+.*'
+  workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: true
 
 permissions:
   contents: write
-  discussions: write
   packages: write
 
 jobs:
-  build:
-    name: Build Release Artifacts
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -31,21 +30,66 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Run linter
+        run: npm run lint
+
+      - name: Generate changelog
+        uses: TriPSs/conventional-changelog-action@v6
+        id: changelog
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-user-name: 'DataBK Auto Release'
+          git-user-email: 'databk.auto.release@github.com'
+          tag-prefix: ''
+          skip-version-file: false
+          version-file: package.json
+
+      - name: Build application
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: npm run build
         env:
           NODE_ENV: production
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-dist
-          path: dist/
-          retention-days: 30
+      - name: Create release archive
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: |
+          cd dist
+          tar -czf ../rustdesk-console-web-${{ steps.changelog.outputs.version }}.tar.gz .
+          cd ..
 
-  release:
-    name: Create GitHub Release
-    needs: build
+      - name: Create GitHub Release
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.changelog.outputs.version }}
+          name: ${{ steps.changelog.outputs.version }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+
+            ## Docker Images
+
+            This release is available on:
+
+            ### Docker Hub
+            ```bash
+            docker pull databk/rustdesk-console-web:${{ steps.changelog.outputs.version }}
+            docker pull databk/rustdesk-console-web:latest
+            ```
+
+            ### GitHub Container Registry
+            ```bash
+            docker pull ghcr.io/databk/rustdesk-console-web:${{ steps.changelog.outputs.version }}
+            docker pull ghcr.io/databk/rustdesk-console-web:latest
+            ```
+          draft: false
+          prerelease: false
+          files: |
+            rustdesk-console-web-${{ steps.changelog.outputs.version }}.tar.gz
+
+  docker:
+    name: Publish Docker Image
+    needs: release
+    if: ${{ needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,52 +99,11 @@ jobs:
 
       - name: Determine version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate changelog
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          output-file: false
-          skip-git-pull: true
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: release-dist
-          path: dist/
-
-      - name: Create release archive
         run: |
-          cd dist
-          tar -czf ../rustdesk-console-web-${{ steps.version.outputs.version }}.tar.gz .
-          cd ..
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          name: ${{ steps.version.outputs.version }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          files: |
-            rustdesk-console-web-${{ steps.version.outputs.version }}.tar.gz
-          discussion_category_name: Releases
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker:
-    name: Publish Docker Image
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Determine version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          VERSION=$(git describe --tags --abbrev=0)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -119,32 +122,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.major }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:latest
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:${{ steps.version.outputs.version }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy Release
     needs: release
+    if: ${{ needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -173,6 +169,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: 'DataBK Auto Release'
+          user_email: 'databk.auto.release@github.com'
           commit_message: 'release: ${{ github.ref_name }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release
+  group: release-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -12,14 +12,12 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: Create Release
+  build:
+    name: Build Release Artifacts
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -30,25 +28,42 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
-        run: npm run lint
-
-      - name: Generate changelog
-        uses: TriPSs/conventional-changelog-action@v6
-        id: changelog
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          git-user-name: 'DataBK Auto Release'
-          git-user-email: 'databk.auto.release@github.com'
-          tag-prefix: ''
-          skip-version-file: false
-          version-file: package.json
-
-      - name: Build application
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+      - name: Build
         run: npm run build
         env:
           NODE_ENV: production
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 30
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: false
+          skip-git-pull: true
+          version-file: package.json
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dist
+          path: dist/
 
       - name: Create release archive
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
@@ -63,26 +78,9 @@ jobs:
         with:
           tag_name: ${{ steps.changelog.outputs.version }}
           name: ${{ steps.changelog.outputs.version }}
-          body: |
-            ${{ steps.changelog.outputs.changelog }}
-
-            ## Docker Images
-
-            This release is available on:
-
-            ### Docker Hub
-            ```bash
-            docker pull databk/rustdesk-console-web:${{ steps.changelog.outputs.version }}
-            docker pull databk/rustdesk-console-web:latest
-            ```
-
-            ### GitHub Container Registry
-            ```bash
-            docker pull ghcr.io/databk/rustdesk-console-web:${{ steps.changelog.outputs.version }}
-            docker pull ghcr.io/databk/rustdesk-console-web:latest
-            ```
+          body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(steps.changelog.outputs.version, '-') }}
           files: |
             rustdesk-console-web-${{ steps.changelog.outputs.version }}.tar.gz
 
@@ -102,8 +100,6 @@ jobs:
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -122,18 +118,26 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.major }}
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:latest
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:${{ steps.version.outputs.version }}
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/rustdesk-console-web:${{ steps.version.outputs.major }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -169,6 +173,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
-          user_name: 'DataBK Auto Release'
-          user_email: 'databk.auto.release@github.com'
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: 'release: ${{ github.ref_name }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,9 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          output-file: false
-          skip-git-pull: true
-          version-file: package.json
+          git-user-name: 'DataBK Auto Release'
+          git-user-email: 'databk.auto.release@github.com'
+          tag-prefix: ''
 
       - name: Download build artifact
         uses: actions/download-artifact@v8
@@ -87,7 +86,6 @@ jobs:
   docker:
     name: Publish Docker Image
     needs: release
-    if: ${{ needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -144,7 +142,6 @@ jobs:
   deploy:
     name: Deploy Release
     needs: release
-    if: ${{ needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustdesk-console-web",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustdesk-console-web",
-      "version": "1.0.0",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustdesk-console-web",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "private": false,
   "description": "Web frontend for RustDesk Console",
   "keywords": [


### PR DESCRIPTION
## Changes

- **Trigger**: Changed from tag push (`[0-9]+.*`) to `workflow_dispatch` for manual release initiation
- **Auto version**: Use `TriPSs/conventional-changelog-action@v6` to auto-generate version number based on conventional commits
- **Update package.json**: The changelog action automatically updates `package.json` with the new version and commits it
- **Remove discussion sync**: Removed `discussion_category_name: Releases` so releases no longer sync to GitHub Discussions
- **Default token**: Use default `GITHUB_TOKEN` instead of custom app token
- **Add lint step**: Run linter before build to ensure code quality
- **Simplify Docker job**: Use direct tag specification instead of metadata action
- **Unify git user**: Consistent `DataBK Auto Release` user across release and deploy steps