### PR TITLE
ci(github workflows): add ref to specify the branch to pull for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Determine version


### PR DESCRIPTION
Fix the issue of incorrect branch being pulled in the release workflow by explicitly specifying to use the ref that triggered the current workflow for code checkout.