### PR TITLE
fix: align react and react-dom versions to 19.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "numeral": "^2.0.6",
         "qrcode.react": "^4.2.0",
         "rc-util": "^5.44.4",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
         "react-helmet-async": "^3.0.0"
       },
       "devDependencies": {
@@ -35862,15 +35862,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "numeral": "^2.0.6",
     "qrcode.react": "^4.2.0",
     "rc-util": "^5.44.4",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "react-helmet-async": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

Docker image builds result in a runtime React error #527:

```
Uncaught Error: Minified React error #527
```

This error occurs when `react` and `react-dom` versions are mismatched. The error URL `?args[]=19.2.7&args[]=19.2.6` confirms the version conflict.

## Root Cause

The `package-lock.json` resolved `react` to **19.2.7** but `react-dom` to **19.2.6**, because both were declared with `^19.1.0` in `package.json`, allowing different patch versions.

## Fix

- Pin both `react` and `react-dom` to exact version **19.2.7** in `package.json`
- Update `package-lock.json` to use `react-dom@19.2.7`

## Testing

Rebuild the Docker image after merging to verify the console loads correctly.