### PR TITLE
fix: resolve invisible 2FA verification inputs and buttons on login page

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -27,7 +27,7 @@ import {
   Input,
   Typography,
 } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStyles, keyframes } from 'antd-style';
 import React, {
   useCallback,
   useEffect,
@@ -80,6 +80,11 @@ const OIDC_LABELS: Record<string, string> = {
 };
 
 // --- Styles ---
+const fadeInAnimation = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
 const useStyles = createStyles(({ token }) => ({
   lang: {
     width: 42,
@@ -119,7 +124,7 @@ const useStyles = createStyles(({ token }) => ({
   verifySection: {
     marginTop: 8,
     opacity: 0,
-    animation: `fadeIn ${token.motionDurationSlow} ${token.motionEaseInOut} forwards`,
+    animation: `${fadeInAnimation} ${token.motionDurationSlow} ${token.motionEaseInOut} forwards`,
   },
   verifyHint: {
     color: token.colorTextSecondary,
@@ -150,10 +155,6 @@ const useStyles = createStyles(({ token }) => ({
     fontSize: 40,
     color: token.colorPrimary,
     marginBottom: 12,
-  },
-  '@keyframes fadeIn': {
-    from: { opacity: 0 },
-    to: { opacity: 1 },
   },
 }));
 


### PR DESCRIPTION
## Problem

The two-factor authentication (TFA) verification step on the login page displays input fields and buttons that are invisible to users. The elements are still interactive (clickable) but cannot be seen, making the 2FA flow unusable.

## Root Cause

The `VerifyStep` component (shared by both email and TFA verification) uses `opacity: 0` with a `fadeIn` CSS animation that should transition to `opacity: 1`. However, the `@keyframes fadeIn` definition was written as a string key inside `createStyles()`:

```js
'@keyframes fadeIn': {
  from: { opacity: 0 },
  to: { opacity: 1 },
},
```

`antd-style`'s CSS-in-JS engine does not process `@keyframes` string keys in `createStyles`, so the keyframe rule was never injected into the DOM. As a result, the animation never ran and `opacity` stayed at `0`, making the verification section invisible.

## Fix

Replace the broken `@keyframes` string key with the proper `keyframes()` function exported by `antd-style`, which correctly generates and injects the animation keyframes:

```js
import { createStyles, keyframes } from 'antd-style';

const fadeInAnimation = keyframes`
  from { opacity: 0; }
  to { opacity: 1; }
`;

// Then reference it in the style:
animation: `${fadeInAnimation} ${token.motionDurationSlow} ${token.motionEaseInOut} forwards`,
```

## Testing

- Verified that the `@keyframes` rule is now properly injected into the DOM
- TypeScript compilation passes with no errors
- The fix applies to both the email verification and TFA verification steps