### PR TITLE
fix: use tfa_type field to determine 2FA verification type on login

### DIFF
--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -495,18 +495,21 @@ const Login: React.FC = () => {
         }
 
         if (msg.type === 'email_check') {
+          const actualType = msg.tfa_type || 'email_check';
           setVerifySession({
             username: values.username?.trim() || '',
             secret: msg.secret || '',
             emailHint: msg.user?.email,
           });
-          setAuthStep('email_check');
-          message.info(
-            intl.formatMessage({
-              id: 'pages.login.emailCheck.sent',
-              defaultMessage: 'A verification code has been sent to your email',
-            }),
-          );
+          setAuthStep(actualType);
+          if (actualType === 'email_check') {
+            message.info(
+              intl.formatMessage({
+                id: 'pages.login.emailCheck.sent',
+                defaultMessage: 'A verification code has been sent to your email',
+              }),
+            );
+          }
           return;
         }
 
@@ -577,6 +580,7 @@ const Login: React.FC = () => {
         }
 
         if (msg.type === 'email_check') {
+          const actualType = msg.tfa_type || 'email_check';
           setVerifySession((prev) =>
             prev
               ? {
@@ -586,7 +590,15 @@ const Login: React.FC = () => {
                 }
               : null,
           );
-          setAuthStep('email_check');
+          setAuthStep(actualType);
+          if (actualType === 'email_check') {
+            message.info(
+              intl.formatMessage({
+                id: 'pages.login.emailCheck.sent',
+                defaultMessage: 'A verification code has been sent to your email',
+              }),
+            );
+          }
           return;
         }
 

--- a/src/pages/user/login/index.tsx
+++ b/src/pages/user/login/index.tsx
@@ -506,7 +506,8 @@ const Login: React.FC = () => {
             message.info(
               intl.formatMessage({
                 id: 'pages.login.emailCheck.sent',
-                defaultMessage: 'A verification code has been sent to your email',
+                defaultMessage:
+                  'A verification code has been sent to your email',
               }),
             );
           }
@@ -595,7 +596,8 @@ const Login: React.FC = () => {
             message.info(
               intl.formatMessage({
                 id: 'pages.login.emailCheck.sent',
-                defaultMessage: 'A verification code has been sent to your email',
+                defaultMessage:
+                  'A verification code has been sent to your email',
               }),
             );
           }


### PR DESCRIPTION
## Problem

When the backend requires two-factor authentication during login, the response `type` is always `'email_check'` regardless of the actual verification method (email verification code or TOTP). This causes the frontend to always show the email verification step even when TOTP is required.

## Solution

Use the `tfa_type` field from the login response to determine the actual verification type:

- When `msg.type === 'email_check'`, read `msg.tfa_type` to get the real verification type
- `tfa_type === 'email_check'` → show email verification step
- `tfa_type === 'tfa_check'` → show TOTP verification step
- Falls back to `msg.type` if `tfa_type` is not present

## Changes

- **`src/pages/user/login/index.tsx`**: Updated both `handleAccountSubmit` and `handleVerifySubmit` to use `tfa_type` for determining the actual auth step when `msg.type === 'email_check'`